### PR TITLE
57 create tournament

### DIFF
--- a/app/src/androidTest/java/com/epfl/drawyourpath/community/TournamentCreationFragmentTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/community/TournamentCreationFragmentTest.kt
@@ -1,0 +1,194 @@
+package com.epfl.drawyourpath.community
+
+import android.widget.DatePicker
+import android.widget.TimePicker
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.PickerActions.setDate
+import androidx.test.espresso.contrib.PickerActions.setTime
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.epfl.drawyourpath.R
+import com.epfl.drawyourpath.mainpage.MainActivity
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+
+@RunWith(AndroidJUnit4::class)
+class TournamentCreationFragmentTest {
+
+    @get:Rule
+    var activityScenarioRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @Before
+    fun launchFragment() {
+        onView(withId(R.id.community_menu_item)).perform(click())
+        onView(withId(R.id.community_menu_button)).perform(click())
+        onView(withText(R.string.create_new_tournament)).perform(click())
+    }
+
+
+    @Test
+    fun createEmptyTournamentShowError() {
+
+        pressCreate()
+
+        onView(withId(R.id.tournament_creation_title_error))
+            .check(matches(withText(R.string.tournament_creation_title_error)))
+            .check(matches(isDisplayed()))
+
+        onView(withId(R.id.tournament_creation_description_error))
+            .check(matches(withText(R.string.tournament_creation_description_error)))
+            .check(matches(isDisplayed()))
+
+        onView(withId(R.id.tournament_creation_visibility_error))
+            .check(matches(withText(R.string.tournament_creation_visibility_error)))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun createTournamentWithPastStartDateAndTimeShowError() {
+
+        selectStartDate(LocalDate.now().minusDays(1L))
+
+        pressCreate()
+
+        onView(withId(R.id.tournament_creation_start_date_error))
+            .check(matches(withText(R.string.tournament_creation_start_date_error)))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun createTournamentWithStartTimeLessThanIntervalShowError() {
+
+        val start = LocalDateTime.now().plus(TournamentCreationFragment.MIN_START_TIME_INTERVAL).minusMinutes(2L)
+
+        selectStartDate(start.toLocalDate())
+        selectStartTime(start.toLocalTime())
+
+        pressCreate()
+
+        onView(withId(R.id.tournament_creation_start_date_error))
+            .check(matches(withText(R.string.tournament_creation_start_date_error)))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun createTournamentWithEndDateBeforeStartDateShowError() {
+
+        selectStartDate(LocalDate.now().plusDays(5L))
+
+        selectEndDate(LocalDate.now().plusDays(4L))
+
+        pressCreate()
+
+        onView(withId(R.id.tournament_creation_end_date_error))
+            .check(matches(withText(R.string.tournament_creation_end_date_error)))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun createTournamentWithEndDateLessThanIntervalFromStartDateShowError() {
+
+        val startDate = LocalDateTime.now().plusDays(5L)
+
+        val endDate = startDate.plus(TournamentCreationFragment.MIN_END_TIME_INTERVAL).minusMinutes(2L)
+
+        selectStartDate(startDate.toLocalDate())
+        selectStartTime(startDate.toLocalTime())
+
+        selectEndDate(endDate.toLocalDate())
+        selectEndTime(endDate.toLocalTime())
+
+        pressCreate()
+
+        onView(withId(R.id.tournament_creation_end_date_error))
+            .check(matches(withText(R.string.tournament_creation_end_date_error)))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun createTournamentWithCorrectValuesGoesToCommunity() {
+        val title = "Discover the earth"
+        val description = "draw the earth"
+        val startDate = LocalDateTime.now().plusDays(5L)
+        val endDate = startDate.plusWeeks(1L)
+        val visibility = Tournament.Visibility.FRIENDS_ONLY
+
+        typeTitle(title)
+
+        typeDescription(description)
+
+        selectStartDate(startDate.toLocalDate())
+        selectStartTime(startDate.toLocalTime())
+
+        selectEndDate(endDate.toLocalDate())
+        selectEndTime(endDate.toLocalTime())
+
+        selectVisibility(visibility)
+
+        pressCreate()
+
+        onView(withId(R.id.fragment_community)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun backButtonGoesToCommunity() {
+        onView(withId(R.id.tournament_creation_back_button)).perform(click())
+
+        onView(withId(R.id.fragment_community)).check(matches(isDisplayed()))
+    }
+
+
+    private fun typeTitle(title: String) {
+        onView(withId(R.id.tournament_creation_title)).perform(typeText(title))
+    }
+
+    private fun typeDescription(description: String) {
+        onView(withId(R.id.tournament_creation_description)).perform(typeText(description))
+    }
+
+    private fun selectStartDate(date: LocalDate) {
+        onView(withId(R.id.tournament_creation_start_date)).perform(click())
+        onView(isAssignableFrom(DatePicker::class.java)).perform(setDate(date.year, date.monthValue, date.dayOfMonth))
+        onView(withId(android.R.id.button1)).perform(click())
+    }
+
+    private fun selectStartTime(time: LocalTime) {
+        onView(withId(R.id.tournament_creation_start_time)).perform(click())
+        onView(isAssignableFrom(TimePicker::class.java)).perform(setTime(time.hour, time.minute))
+        onView(withId(android.R.id.button1)).perform(click())
+    }
+
+    private fun selectEndDate(date: LocalDate) {
+        onView(withId(R.id.tournament_creation_end_date)).perform(click())
+        onView(isAssignableFrom(DatePicker::class.java)).perform(setDate(date.year, date.monthValue, date.dayOfMonth))
+        onView(withId(android.R.id.button1)).perform(click())
+    }
+
+    private fun selectEndTime(time: LocalTime) {
+        onView(withId(R.id.tournament_creation_end_time)).perform(click())
+        onView(isAssignableFrom(TimePicker::class.java)).perform(setTime(time.hour, time.minute))
+        onView(withId(android.R.id.button1)).perform(click())
+    }
+
+    private fun selectVisibility(visibility: Tournament.Visibility) {
+        when (visibility.ordinal) {
+            0 -> onView(withId(R.id.tournament_creation_visibility_item_0)).perform(click())
+            1 -> onView(withId(R.id.tournament_creation_visibility_item_1)).perform(click())
+        }
+    }
+
+    private fun pressCreate() {
+        onView(withId(R.id.tournament_creation_create_button)).perform(click())
+    }
+
+}

--- a/app/src/androidTest/java/com/epfl/drawyourpath/community/TournamentCreationFragmentTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/community/TournamentCreationFragmentTest.kt
@@ -2,9 +2,9 @@ package com.epfl.drawyourpath.community
 
 import android.widget.DatePicker
 import android.widget.TimePicker
+import androidx.test.espresso.Espresso.closeSoftKeyboard
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.action.ViewActions.*
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.PickerActions.setDate
 import androidx.test.espresso.contrib.PickerActions.setTime
@@ -42,14 +42,17 @@ class TournamentCreationFragmentTest {
         pressCreate()
 
         onView(withId(R.id.tournament_creation_title_error))
+            .perform(scrollTo())
             .check(matches(withText(R.string.tournament_creation_title_error)))
             .check(matches(isDisplayed()))
 
         onView(withId(R.id.tournament_creation_description_error))
+            .perform(scrollTo())
             .check(matches(withText(R.string.tournament_creation_description_error)))
             .check(matches(isDisplayed()))
 
         onView(withId(R.id.tournament_creation_visibility_error))
+            .perform(scrollTo())
             .check(matches(withText(R.string.tournament_creation_visibility_error)))
             .check(matches(isDisplayed()))
     }
@@ -62,6 +65,7 @@ class TournamentCreationFragmentTest {
         pressCreate()
 
         onView(withId(R.id.tournament_creation_start_date_error))
+            .perform(scrollTo())
             .check(matches(withText(R.string.tournament_creation_start_date_error)))
             .check(matches(isDisplayed()))
     }
@@ -77,6 +81,7 @@ class TournamentCreationFragmentTest {
         pressCreate()
 
         onView(withId(R.id.tournament_creation_start_date_error))
+            .perform(scrollTo())
             .check(matches(withText(R.string.tournament_creation_start_date_error)))
             .check(matches(isDisplayed()))
     }
@@ -91,6 +96,7 @@ class TournamentCreationFragmentTest {
         pressCreate()
 
         onView(withId(R.id.tournament_creation_end_date_error))
+            .perform(scrollTo())
             .check(matches(withText(R.string.tournament_creation_end_date_error)))
             .check(matches(isDisplayed()))
     }
@@ -111,6 +117,7 @@ class TournamentCreationFragmentTest {
         pressCreate()
 
         onView(withId(R.id.tournament_creation_end_date_error))
+            .perform(scrollTo())
             .check(matches(withText(R.string.tournament_creation_end_date_error)))
             .check(matches(isDisplayed()))
     }
@@ -149,46 +156,48 @@ class TournamentCreationFragmentTest {
 
 
     private fun typeTitle(title: String) {
-        onView(withId(R.id.tournament_creation_title)).perform(typeText(title))
+        onView(withId(R.id.tournament_creation_title)).perform(scrollTo(),typeText(title))
+        closeSoftKeyboard()
     }
 
     private fun typeDescription(description: String) {
-        onView(withId(R.id.tournament_creation_description)).perform(typeText(description))
+        onView(withId(R.id.tournament_creation_description)).perform(scrollTo(),typeText(description))
+        closeSoftKeyboard()
     }
 
     private fun selectStartDate(date: LocalDate) {
-        onView(withId(R.id.tournament_creation_start_date)).perform(click())
+        onView(withId(R.id.tournament_creation_start_date)).perform(scrollTo(),click())
         onView(isAssignableFrom(DatePicker::class.java)).perform(setDate(date.year, date.monthValue, date.dayOfMonth))
         onView(withId(android.R.id.button1)).perform(click())
     }
 
     private fun selectStartTime(time: LocalTime) {
-        onView(withId(R.id.tournament_creation_start_time)).perform(click())
+        onView(withId(R.id.tournament_creation_start_time)).perform(scrollTo(),click())
         onView(isAssignableFrom(TimePicker::class.java)).perform(setTime(time.hour, time.minute))
         onView(withId(android.R.id.button1)).perform(click())
     }
 
     private fun selectEndDate(date: LocalDate) {
-        onView(withId(R.id.tournament_creation_end_date)).perform(click())
+        onView(withId(R.id.tournament_creation_end_date)).perform(scrollTo(),click())
         onView(isAssignableFrom(DatePicker::class.java)).perform(setDate(date.year, date.monthValue, date.dayOfMonth))
         onView(withId(android.R.id.button1)).perform(click())
     }
 
     private fun selectEndTime(time: LocalTime) {
-        onView(withId(R.id.tournament_creation_end_time)).perform(click())
+        onView(withId(R.id.tournament_creation_end_time)).perform(scrollTo(),click())
         onView(isAssignableFrom(TimePicker::class.java)).perform(setTime(time.hour, time.minute))
         onView(withId(android.R.id.button1)).perform(click())
     }
 
     private fun selectVisibility(visibility: Tournament.Visibility) {
         when (visibility.ordinal) {
-            0 -> onView(withId(R.id.tournament_creation_visibility_item_0)).perform(click())
-            1 -> onView(withId(R.id.tournament_creation_visibility_item_1)).perform(click())
+            0 -> onView(withId(R.id.tournament_creation_visibility_item_0)).perform(scrollTo(),click())
+            1 -> onView(withId(R.id.tournament_creation_visibility_item_1)).perform(scrollTo(),click())
         }
     }
 
     private fun pressCreate() {
-        onView(withId(R.id.tournament_creation_create_button)).perform(click())
+        onView(withId(R.id.tournament_creation_create_button)).perform(scrollTo(), click())
     }
 
 }

--- a/app/src/androidTest/java/com/epfl/drawyourpath/mainpage/fragments/CommunityFragmentTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/mainpage/fragments/CommunityFragmentTest.kt
@@ -3,6 +3,7 @@ package com.epfl.drawyourpath.mainpage.fragments
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.testing.FragmentScenario
+import androidx.lifecycle.ViewModel
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.UiController
@@ -243,7 +244,7 @@ class CommunityFragmentTest {
 
     private fun getBundle(weekly: Tournament, your: List<Tournament> = listOf(), discover: List<Tournament> = listOf()): Bundle {
         val bundle = Bundle()
-        bundle.putSerializable("tournaments", TournamentModel(weekly, your, discover))
+        bundle.putSerializable("tournaments", TournamentModel.SampleTournamentModel(weekly, your, discover))
         return bundle
     }
 

--- a/app/src/main/java/com/epfl/drawyourpath/community/Tournament.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/community/Tournament.kt
@@ -3,6 +3,7 @@ package com.epfl.drawyourpath.community
 import java.time.Clock
 import java.time.Duration
 import java.time.LocalDateTime
+import java.util.*
 
 /**
  * class representing tournaments that the user can take part in
@@ -12,7 +13,8 @@ data class Tournament(
     val description: String,
     val startDate: LocalDateTime,
     val endDate: LocalDateTime,
-    var posts: List<TournamentPost> = mutableListOf()
+    var posts: List<TournamentPost> = mutableListOf(),
+    var visibility: Visibility = Visibility.PUBLIC
     //val result: List<User>?
 ) : java.io.Serializable {
 
@@ -63,6 +65,10 @@ data class Tournament(
             res.append(" minutes")
         }
         return res.toString()
+    }
+
+    enum class Visibility {
+        FRIENDS_ONLY, PUBLIC
     }
 
 

--- a/app/src/main/java/com/epfl/drawyourpath/community/TournamentCreationFragment.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/community/TournamentCreationFragment.kt
@@ -1,0 +1,132 @@
+package com.epfl.drawyourpath.community
+
+import android.app.DatePickerDialog
+import android.app.Dialog
+import android.app.TimePickerDialog
+import android.os.Bundle
+import android.view.View
+import android.widget.DatePicker
+import android.widget.ImageButton
+import android.widget.TextView
+import android.widget.TimePicker
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.commit
+import androidx.fragment.app.replace
+import com.epfl.drawyourpath.R
+import com.epfl.drawyourpath.mainpage.fragments.CommunityFragment
+import java.time.LocalDate
+import java.time.LocalTime
+
+class TournamentCreationFragment : Fragment(R.layout.fragment_tournament_creation) {
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        createBackButton(view)
+
+        createStartDateAndTime(view)
+
+    }
+
+    private fun createStartDateAndTime(view: View) {
+        val startDate = view.findViewById<TextView>(R.id.tournament_creation_start_date)
+        startDate.setOnClickListener {
+            DatePickerFragment(startDate).show(activity?.supportFragmentManager!!, "startDatePicker")
+        }
+        val startTime = view.findViewById<TextView>(R.id.tournament_creation_start_time)
+        startTime.setOnClickListener {
+            TimePickerFragment(startTime).show(activity?.supportFragmentManager!!, "startTimePicker")
+        }
+    }
+
+
+    /**
+     * create the back button
+     */
+    private fun createBackButton(view: View) {
+        val backButton = view.findViewById<ImageButton>(R.id.tournament_creation_back_button)
+        backButton.setOnClickListener {
+            replaceFragment<CommunityFragment>()
+        }
+    }
+
+    /**
+     * replace this fragment by another one
+     */
+    private inline fun <reified F : Fragment> replaceFragment() {
+        activity?.supportFragmentManager?.commit {
+            setReorderingAllowed(true)
+            replace<F>(R.id.fragmentContainerView)
+        }
+    }
+
+    /**
+     * create a datePicker
+     */
+    class DatePickerFragment(text: TextView) : DialogFragment(), DatePickerDialog.OnDateSetListener {
+        private val text: TextView
+        var dateSelected = LocalDate.now()
+
+        init {
+            this.text = text
+        }
+
+        override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+            //create a new instance of date picker
+            //use the current date as the default date in the picker
+            return DatePickerDialog(
+                requireContext(),
+                this,
+                dateSelected.year,
+                dateSelected.monthValue - 1,
+                dateSelected.dayOfMonth
+            )
+        }
+
+        override fun onDateSet(view: DatePicker, year: Int, month: Int, day: Int) {
+            text.text = buildString {
+                append(day)
+                append(" / ")
+                append(month + 1)
+                append(" / ")
+                append(year)
+            }
+            dateSelected = LocalDate.of(year, month + 1, day)
+        }
+    }
+
+    /**
+     * create a time picker
+     */
+    class TimePickerFragment(text: TextView) : DialogFragment(), TimePickerDialog.OnTimeSetListener {
+        private val text: TextView
+        var timeSelected = LocalTime.now()
+
+        init {
+            this.text = text
+        }
+
+        override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+            //create a new instance of time picker
+            //use the current time + 1 hour and 0 minute as the default time in the picker
+            return TimePickerDialog(
+                requireContext(),
+                this,
+                (timeSelected.hour + 1) % 24,
+                0,
+                true
+            )
+        }
+
+        override fun onTimeSet(view: TimePicker?, hourOfDay: Int, minute: Int) {
+            text.text = buildString {
+                append(hourOfDay)
+                append(" : ")
+                append(minute)
+            }
+            timeSelected = LocalTime.of(hourOfDay, minute)
+        }
+    }
+
+}

--- a/app/src/main/java/com/epfl/drawyourpath/community/TournamentCreationFragment.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/community/TournamentCreationFragment.kt
@@ -84,23 +84,23 @@ class TournamentCreationFragment : Fragment(R.layout.fragment_tournament_creatio
         var error = false
 
         //check title
-        error = error or checkConstraint(tournamentTitle.isBlank(), "* Title should not be empty", titleError)
+        error = error or checkConstraint(tournamentTitle.isBlank(), getString(R.string.tournament_creation_title_error), titleError)
         //check description
-        error = error or checkConstraint(tournamentDescription.isBlank(), "* Description should not be empty", descriptionError)
+        error = error or checkConstraint(tournamentDescription.isBlank(), getString(R.string.tournament_creation_description_error), descriptionError)
         //check start date and time
         error = error or checkConstraint(
             tournamentStartDate < LocalDateTime.now().plus(MIN_START_TIME_INTERVAL),
-            "* Starting time and date should be at least 1 hour from now",
+            getString(R.string.tournament_creation_start_date_error),
             startDateError
         )
         //check end date and time
         error = error or checkConstraint(
             tournamentEndDate < tournamentStartDate.plus(MIN_END_TIME_INTERVAL),
-            "* Ending time and date should be at least 1 day from starting day and time",
+            getString(R.string.tournament_creation_end_date_error),
             endDateError
         )
         //check visibility
-        error = error or checkConstraint(tournamentVisibility == -1, "* One visibility option should be checked", visibilityError)
+        error = error or checkConstraint(tournamentVisibility == -1, getString(R.string.tournament_creation_visibility_error), visibilityError)
 
         if (error) {
             return null
@@ -115,6 +115,15 @@ class TournamentCreationFragment : Fragment(R.layout.fragment_tournament_creatio
         )
     }
 
+    /**
+     * check if the constraint holds or not and show the error message accordingly
+     *
+     * @param isError the constraint
+     * @param errorText the error message
+     * @param error the text view used to show the error message
+     * @return [isError]
+     *
+     */
     private fun checkConstraint(isError: Boolean, errorText: String, error: TextView): Boolean {
         if (isError) {
             error.text = errorText
@@ -125,18 +134,35 @@ class TournamentCreationFragment : Fragment(R.layout.fragment_tournament_creatio
         return isError
     }
 
+    /**
+     * create the visibility radio button
+     */
     private fun createVisibilityRadioButton(view: View) {
-        setVisibility(0, view.findViewById<RadioButton>(R.id.tournament_creation_visibility_item_0))
-        setVisibility(1, view.findViewById<RadioButton>(R.id.tournament_creation_visibility_item_1))
+        setVisibility(0, view.findViewById(R.id.tournament_creation_visibility_item_0))
+        setVisibility(1, view.findViewById(R.id.tournament_creation_visibility_item_1))
     }
 
-    private fun getVisibility(text: TextView): Tournament.Visibility {
-        return Tournament.Visibility.valueOf(text.text.toString().uppercase().replace(" ", "_"))
+    /**
+     * get the visibility from the radio button
+     *
+     * @param radioButton the radio button
+     * @return [Tournament.Visibility] the visibility
+     *
+     */
+    private fun getVisibility(radioButton: RadioButton): Tournament.Visibility {
+        return Tournament.Visibility.valueOf(radioButton.text.toString().uppercase().replace(" ", "_"))
     }
 
-    private fun setVisibility(index: Int, text: TextView) {
-        val name = Tournament.Visibility.values()[index].name.lowercase().replace("_", " ").replaceFirstChar { c -> c.uppercaseChar() }
-        text.text = name
+    /**
+     * set the visibility name to the radio button
+     *
+     * @param index the ordinal of the [Tournament.Visibility] enum
+     * @param radioButton the radio button
+     *
+     */
+    private fun setVisibility(index: Int, radioButton: RadioButton) {
+        radioButton.text = Tournament.Visibility.values()[index].name.lowercase().replace("_", " ")
+            .replaceFirstChar { c -> c.uppercaseChar() }
     }
 
     /**
@@ -152,6 +178,9 @@ class TournamentCreationFragment : Fragment(R.layout.fragment_tournament_creatio
         visibility = view.findViewById(R.id.tournament_creation_visibility)
     }
 
+    /**
+     * set the start date/time and the end date/date to default values
+     */
     private fun setDefaultTimeAndDate() {
         setDate(DEFAULT_START_DATE, startDate)
         setTime(DEFAULT_START_TIME, startTime)
@@ -202,8 +231,8 @@ class TournamentCreationFragment : Fragment(R.layout.fragment_tournament_creatio
         private val DEFAULT_START_TIME = LocalTime.now().plusHours(2L).minusMinutes(LocalTime.now().minute.toLong())
         private val DEFAULT_END_DATE = DEFAULT_START_DATE.plusWeeks(1L)
         private val DEFAULT_END_TIME = DEFAULT_START_TIME
-        private val MIN_START_TIME_INTERVAL = Duration.of(1L, ChronoUnit.HOURS)
-        private val MIN_END_TIME_INTERVAL = Duration.of(1L, ChronoUnit.DAYS)
+        val MIN_START_TIME_INTERVAL: Duration = Duration.of(1L, ChronoUnit.HOURS)
+        val MIN_END_TIME_INTERVAL: Duration = Duration.of(1L, ChronoUnit.DAYS)
 
         /**
          * get the date from the date text view

--- a/app/src/main/java/com/epfl/drawyourpath/community/TournamentCreationFragment.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/community/TournamentCreationFragment.kt
@@ -5,10 +5,7 @@ import android.app.Dialog
 import android.app.TimePickerDialog
 import android.os.Bundle
 import android.view.View
-import android.widget.DatePicker
-import android.widget.ImageButton
-import android.widget.TextView
-import android.widget.TimePicker
+import android.widget.*
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
@@ -16,27 +13,160 @@ import androidx.fragment.app.replace
 import com.epfl.drawyourpath.R
 import com.epfl.drawyourpath.mainpage.fragments.CommunityFragment
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 class TournamentCreationFragment : Fragment(R.layout.fragment_tournament_creation) {
 
+    private lateinit var title: TextView
+    private lateinit var description: TextView
+    private lateinit var startDate: TextView
+    private lateinit var startTime: TextView
+    private lateinit var endDate: TextView
+    private lateinit var endTime: TextView
+
+    //TODO add visibility to tournament
+    private lateinit var visibility: RadioGroup
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        initVariable(view)
+        setDefaultTimeAndDate()
+
         createBackButton(view)
 
-        createStartDateAndTime(view)
+        createVisibilityRadioButton(view)
+
+        createDateAndTime(startDate, startTime)
+
+        createDateAndTime(endDate, endTime)
+
+        createCreateButton(view)
 
     }
 
-    private fun createStartDateAndTime(view: View) {
-        val startDate = view.findViewById<TextView>(R.id.tournament_creation_start_date)
-        startDate.setOnClickListener {
-            DatePickerFragment(startDate).show(activity?.supportFragmentManager!!, "startDatePicker")
+    /**
+     * create the create button
+     */
+    private fun createCreateButton(view: View) {
+        val createButton = view.findViewById<Button>(R.id.tournament_creation_create_button)
+        createButton.setOnClickListener {
+            val newTournament = checkTournamentConstraints(view)
+            if (newTournament != null) {
+                //TODO add tournament
+                replaceFragment<CommunityFragment>()
+            }
         }
-        val startTime = view.findViewById<TextView>(R.id.tournament_creation_start_time)
-        startTime.setOnClickListener {
-            TimePickerFragment(startTime).show(activity?.supportFragmentManager!!, "startTimePicker")
+    }
+
+    /**
+     * check the constraints on the tournament
+     *
+     * @return the tournament if the constraints are satisfied else null
+     */
+    private fun checkTournamentConstraints(view: View): Tournament? {
+        val titleError = view.findViewById<TextView>(R.id.tournament_creation_title_error)
+        val descriptionError = view.findViewById<TextView>(R.id.tournament_creation_description_error)
+        val startDateError = view.findViewById<TextView>(R.id.tournament_creation_start_date_error)
+        val endDateError = view.findViewById<TextView>(R.id.tournament_creation_end_date_error)
+        val visibilityError = view.findViewById<TextView>(R.id.tournament_creation_visibility_error)
+
+        val tournamentTitle = title.text
+        val tournamentDescription = description.text
+        val tournamentStartDate = LocalDateTime.of(getDate(startDate), getTime(startTime))
+        val tournamentEndDate = LocalDateTime.of(getDate(endDate), getTime(endTime))
+        val tournamentVisibility = visibility.checkedRadioButtonId
+
+        var error = false
+
+        //check title
+        error = error or checkConstraint(tournamentTitle.isBlank(), "* Title should not be empty", titleError)
+        //check description
+        error = error or checkConstraint(tournamentDescription.isBlank(), "* Description should not be empty", descriptionError)
+        //check start date and time
+        error = error or checkConstraint(
+            tournamentStartDate < LocalDateTime.now().plusHours(1L),
+            "* Starting time and date should be at least 1 hour from now",
+            startDateError
+        )
+        //check end date and time
+        error = error or checkConstraint(
+            tournamentEndDate < tournamentStartDate.plusDays(1L),
+            "* Ending time and date should be at least 1 day from starting day and time",
+            endDateError
+        )
+        //check visibility
+        error = error or checkConstraint(tournamentVisibility == -1, "* One visibility option should be checked", visibilityError)
+
+        if (error) {
+            return null
+        }
+
+        return Tournament(
+            tournamentTitle.toString(),
+            tournamentDescription.toString(),
+            tournamentStartDate,
+            tournamentEndDate,
+            visibility = getVisibility(view.findViewById(tournamentVisibility))
+        )
+    }
+
+    private fun checkConstraint(isError: Boolean, errorText: String, error: TextView): Boolean {
+        if (isError) {
+            error.text = errorText
+            error.visibility = View.VISIBLE
+        } else {
+            error.visibility = View.GONE
+        }
+        return isError
+    }
+
+    private fun createVisibilityRadioButton(view: View) {
+        setVisibility(0, view.findViewById<RadioButton>(R.id.tournament_creation_visibility_item_0))
+        setVisibility(1, view.findViewById<RadioButton>(R.id.tournament_creation_visibility_item_1))
+    }
+
+    private fun getVisibility(text: TextView): Tournament.Visibility {
+        return Tournament.Visibility.valueOf(text.text.toString().uppercase().replace(" ", "_"))
+    }
+
+    private fun setVisibility(index: Int, text: TextView) {
+        val name = Tournament.Visibility.values()[index].name.lowercase().replace("_", " ").replaceFirstChar { c -> c.uppercaseChar() }
+        text.text = name
+    }
+
+    /**
+     * initialize the variable
+     */
+    private fun initVariable(view: View) {
+        title = view.findViewById(R.id.tournament_creation_title)
+        description = view.findViewById(R.id.tournament_creation_description)
+        startDate = view.findViewById(R.id.tournament_creation_start_date)
+        startTime = view.findViewById(R.id.tournament_creation_start_time)
+        endDate = view.findViewById(R.id.tournament_creation_end_date)
+        endTime = view.findViewById(R.id.tournament_creation_end_time)
+        visibility = view.findViewById(R.id.tournament_creation_visibility)
+    }
+
+    private fun setDefaultTimeAndDate() {
+        setDate(DEFAULT_START_DATE, startDate)
+        setTime(DEFAULT_START_TIME, startTime)
+        setDate(DEFAULT_END_DATE, endDate)
+        setTime(DEFAULT_END_TIME, endTime)
+    }
+
+    /**
+     * create the date and time
+     * @param date the start or end date
+     * @param time the start or end time
+     */
+    private fun createDateAndTime(date: TextView, time: TextView) {
+        date.setOnClickListener {
+            DatePickerFragment(date).show(activity?.supportFragmentManager!!, "startDatePicker")
+        }
+        time.setOnClickListener {
+            TimePickerFragment(time).show(activity?.supportFragmentManager!!, "startTimePicker")
         }
     }
 
@@ -51,6 +181,7 @@ class TournamentCreationFragment : Fragment(R.layout.fragment_tournament_creatio
         }
     }
 
+
     /**
      * replace this fragment by another one
      */
@@ -61,12 +192,61 @@ class TournamentCreationFragment : Fragment(R.layout.fragment_tournament_creatio
         }
     }
 
+    companion object {
+        private const val DATE_SEPARATOR = " / "
+        private const val TIME_SEPARATOR = " : "
+        private val DEFAULT_START_DATE = LocalDate.now()
+        private val DEFAULT_START_TIME = LocalTime.now().plusHours(1L).minusMinutes(LocalTime.now().minute.toLong())
+        private val DEFAULT_END_DATE = DEFAULT_START_DATE.plusWeeks(1L)
+        private val DEFAULT_END_TIME = DEFAULT_START_TIME
+
+        /**
+         * get the date from the date text view
+         */
+        private fun getDate(date: TextView): LocalDate {
+            val texts = date.text.split(DATE_SEPARATOR)
+            return LocalDate.of(texts[2].toInt(), texts[1].toInt(), texts[0].toInt())
+        }
+
+        /**
+         * get the time from the time text view
+         */
+        private fun getTime(time: TextView): LocalTime {
+            val texts = time.text.split(TIME_SEPARATOR)
+            return LocalTime.of(texts[0].toInt(), texts[1].toInt())
+        }
+
+        /**
+         * set the date to the date text
+         */
+        private fun setDate(date: LocalDate, text: TextView) {
+            text.text = buildString {
+                append("%02d".format(date.dayOfMonth))
+                append(DATE_SEPARATOR)
+                append("%02d".format(date.monthValue))
+                append(DATE_SEPARATOR)
+                append(date.year)
+            }
+        }
+
+        /**
+         * set the time to the time text
+         */
+        private fun setTime(time: LocalTime, text: TextView) {
+            text.text = buildString {
+                append("%02d".format(time.hour))
+                append(TIME_SEPARATOR)
+                append("%02d".format(time.minute))
+            }
+        }
+
+    }
+
     /**
      * create a datePicker
      */
     class DatePickerFragment(text: TextView) : DialogFragment(), DatePickerDialog.OnDateSetListener {
         private val text: TextView
-        var dateSelected = LocalDate.now()
 
         init {
             this.text = text
@@ -74,25 +254,19 @@ class TournamentCreationFragment : Fragment(R.layout.fragment_tournament_creatio
 
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
             //create a new instance of date picker
-            //use the current date as the default date in the picker
+
+            val date = getDate(text)
             return DatePickerDialog(
                 requireContext(),
                 this,
-                dateSelected.year,
-                dateSelected.monthValue - 1,
-                dateSelected.dayOfMonth
+                date.year,
+                date.monthValue - 1,
+                date.dayOfMonth
             )
         }
 
         override fun onDateSet(view: DatePicker, year: Int, month: Int, day: Int) {
-            text.text = buildString {
-                append(day)
-                append(" / ")
-                append(month + 1)
-                append(" / ")
-                append(year)
-            }
-            dateSelected = LocalDate.of(year, month + 1, day)
+            setDate(LocalDate.of(year, month + 1, day), text)
         }
     }
 
@@ -101,7 +275,6 @@ class TournamentCreationFragment : Fragment(R.layout.fragment_tournament_creatio
      */
     class TimePickerFragment(text: TextView) : DialogFragment(), TimePickerDialog.OnTimeSetListener {
         private val text: TextView
-        var timeSelected = LocalTime.now()
 
         init {
             this.text = text
@@ -109,23 +282,19 @@ class TournamentCreationFragment : Fragment(R.layout.fragment_tournament_creatio
 
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
             //create a new instance of time picker
-            //use the current time + 1 hour and 0 minute as the default time in the picker
+
+            val time = getTime(text)
             return TimePickerDialog(
                 requireContext(),
                 this,
-                (timeSelected.hour + 1) % 24,
-                0,
+                time.hour,
+                time.minute,
                 true
             )
         }
 
         override fun onTimeSet(view: TimePicker?, hourOfDay: Int, minute: Int) {
-            text.text = buildString {
-                append(hourOfDay)
-                append(" : ")
-                append(minute)
-            }
-            timeSelected = LocalTime.of(hourOfDay, minute)
+            setTime(LocalTime.of(hourOfDay, minute), text)
         }
     }
 

--- a/app/src/main/java/com/epfl/drawyourpath/community/TournamentCreationFragment.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/community/TournamentCreationFragment.kt
@@ -12,9 +12,11 @@ import androidx.fragment.app.commit
 import androidx.fragment.app.replace
 import com.epfl.drawyourpath.R
 import com.epfl.drawyourpath.mainpage.fragments.CommunityFragment
+import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.temporal.ChronoUnit
 
 class TournamentCreationFragment : Fragment(R.layout.fragment_tournament_creation) {
 
@@ -32,6 +34,7 @@ class TournamentCreationFragment : Fragment(R.layout.fragment_tournament_creatio
         super.onViewCreated(view, savedInstanceState)
 
         initVariable(view)
+
         setDefaultTimeAndDate()
 
         createBackButton(view)
@@ -86,13 +89,13 @@ class TournamentCreationFragment : Fragment(R.layout.fragment_tournament_creatio
         error = error or checkConstraint(tournamentDescription.isBlank(), "* Description should not be empty", descriptionError)
         //check start date and time
         error = error or checkConstraint(
-            tournamentStartDate < LocalDateTime.now().plusHours(1L),
+            tournamentStartDate < LocalDateTime.now().plus(MIN_START_TIME_INTERVAL),
             "* Starting time and date should be at least 1 hour from now",
             startDateError
         )
         //check end date and time
         error = error or checkConstraint(
-            tournamentEndDate < tournamentStartDate.plusDays(1L),
+            tournamentEndDate < tournamentStartDate.plus(MIN_END_TIME_INTERVAL),
             "* Ending time and date should be at least 1 day from starting day and time",
             endDateError
         )
@@ -196,9 +199,11 @@ class TournamentCreationFragment : Fragment(R.layout.fragment_tournament_creatio
         private const val DATE_SEPARATOR = " / "
         private const val TIME_SEPARATOR = " : "
         private val DEFAULT_START_DATE = LocalDate.now()
-        private val DEFAULT_START_TIME = LocalTime.now().plusHours(1L).minusMinutes(LocalTime.now().minute.toLong())
+        private val DEFAULT_START_TIME = LocalTime.now().plusHours(2L).minusMinutes(LocalTime.now().minute.toLong())
         private val DEFAULT_END_DATE = DEFAULT_START_DATE.plusWeeks(1L)
         private val DEFAULT_END_TIME = DEFAULT_START_TIME
+        private val MIN_START_TIME_INTERVAL = Duration.of(1L, ChronoUnit.HOURS)
+        private val MIN_END_TIME_INTERVAL = Duration.of(1L, ChronoUnit.DAYS)
 
         /**
          * get the date from the date text view

--- a/app/src/main/java/com/epfl/drawyourpath/community/TournamentModel.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/community/TournamentModel.kt
@@ -3,11 +3,11 @@ package com.epfl.drawyourpath.community
 /**
  *
  */
-data class TournamentModel(
-    private var weekly: Tournament,
-    private var your: List<Tournament> = mutableListOf(),
+class TournamentModel : java.io.Serializable {
+
+    private var weekly: Tournament? = null
+    private var your: List<Tournament> = mutableListOf()
     private var discover: List<Tournament> = mutableListOf()
-) : java.io.Serializable {
 
     /**
      * get the tournament of this week
@@ -15,7 +15,7 @@ data class TournamentModel(
      *
      * @return the weekly tournament
      */
-    fun getWeeklyTournament(): Tournament {
+    fun getWeeklyTournament(): Tournament? {
         return weekly
     }
 
@@ -41,6 +41,12 @@ data class TournamentModel(
         return discover.toList()
     }
 
-    //TODO link the tournaments with the database
+    fun setSample(sample: SampleTournamentModel) {
+        weekly = sample.weekly
+        your = sample.your
+        discover = sample.discover
+    }
+
+    data class SampleTournamentModel(val weekly: Tournament, val your: List<Tournament>, val discover: List<Tournament>) : java.io.Serializable
 
 }

--- a/app/src/main/java/com/epfl/drawyourpath/community/TournamentPost.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/community/TournamentPost.kt
@@ -2,13 +2,15 @@ package com.epfl.drawyourpath.community
 
 import com.github.drawyourpath.bootcamp.path.Run
 import java.time.LocalDateTime
+import java.util.*
+import kotlin.collections.HashMap
 
 data class TournamentPost(
     val user: String, //TODO change to a real user
     val run: Run,
     private var votes: Int = 0,
     val date: LocalDateTime = LocalDateTime.now(),
-    private var userVotes: HashMap<String, Int> = HashMap(),
+    private var userVotes: HashMap<String, Int> = HashMap()
 ) : java.io.Serializable {
 
     /**

--- a/app/src/main/java/com/epfl/drawyourpath/mainpage/fragments/CommunityFragment.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/mainpage/fragments/CommunityFragment.kt
@@ -34,8 +34,7 @@ class CommunityFragment : Fragment(R.layout.fragment_community) {
     private lateinit var detailsLayout: LinearLayout
     private lateinit var tournamentPostsView: RecyclerView
     private lateinit var scroll: NestedScrollView
-
-    private lateinit var tournament: TournamentModel
+    private val tournament = TournamentModel()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -66,7 +65,7 @@ class CommunityFragment : Fragment(R.layout.fragment_community) {
         tournamentPostsView = view.findViewById(R.id.display_community_tournaments_view)
         scroll = view.findViewById(R.id.community_nested_scroll_view)
 
-        tournament = TournamentModel(sampleWeekly(), sampleYourTournaments(), sampleDiscoveryTournaments())
+        tournament.setSample(TournamentModel.SampleTournamentModel(sampleWeekly(), sampleYourTournaments(), sampleDiscoveryTournaments()))
     }
 
     /**
@@ -75,7 +74,7 @@ class CommunityFragment : Fragment(R.layout.fragment_community) {
      */
     private fun getTournaments() {
         if (arguments?.getSerializable("tournaments") != null) {
-            tournament = arguments?.getSerializable("tournaments") as TournamentModel
+            tournament.setSample(arguments?.getSerializable("tournaments") as TournamentModel.SampleTournamentModel)
         }
     }
 
@@ -129,7 +128,9 @@ class CommunityFragment : Fragment(R.layout.fragment_community) {
         createTournamentButton(menu)
 
         val weekly = menu.addSubMenu("Weekly tournament")
-        createMenuItem(view, weekly, tournament.getWeeklyTournament())
+        if (tournament.getWeeklyTournament() != null) {
+            createMenuItem(view, weekly, tournament.getWeeklyTournament()!!)
+        }
 
         val your = menu.addSubMenu("Your tournament")
         for (t in tournament.getYourTournament("placeholder")) {
@@ -204,7 +205,10 @@ class CommunityFragment : Fragment(R.layout.fragment_community) {
      * @return the list of all tournaments
      */
     private fun getAllTournaments(): List<Tournament> {
-        val list = mutableListOf(tournament.getWeeklyTournament())
+        val list = mutableListOf<Tournament>()
+        if (tournament.getWeeklyTournament() != null) {
+            list.add(tournament.getWeeklyTournament()!!)
+        }
         list.addAll(tournament.getYourTournament("placeholder"))
         list.addAll(tournament.getDiscoverTournament("placeholder"))
         return list

--- a/app/src/main/java/com/epfl/drawyourpath/mainpage/fragments/CommunityFragment.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/mainpage/fragments/CommunityFragment.kt
@@ -143,7 +143,7 @@ class CommunityFragment : Fragment(R.layout.fragment_community) {
     }
 
     private fun createTournamentButton(menu: Menu) {
-        menu.add("Create new tournament")
+        menu.add(getString(R.string.create_new_tournament))
             .setIcon(R.drawable.ic_add)
             .setOnMenuItemClickListener {
                 replaceFragment<TournamentCreationFragment>()

--- a/app/src/main/java/com/epfl/drawyourpath/mainpage/fragments/CommunityFragment.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/mainpage/fragments/CommunityFragment.kt
@@ -1,6 +1,7 @@
 package com.epfl.drawyourpath.mainpage.fragments
 
 import android.os.Bundle
+import android.view.Menu
 import android.view.SubMenu
 import android.view.View
 import android.widget.ImageButton
@@ -9,13 +10,12 @@ import android.widget.TextView
 import androidx.core.widget.NestedScrollView
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.commit
+import androidx.fragment.app.replace
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.epfl.drawyourpath.R
-import com.epfl.drawyourpath.community.CommunityTournamentPostViewAdapter
-import com.epfl.drawyourpath.community.Tournament
-import com.epfl.drawyourpath.community.TournamentModel
-import com.epfl.drawyourpath.community.TournamentPost
+import com.epfl.drawyourpath.community.*
 import com.epfl.drawyourpath.path.Path
 import com.github.drawyourpath.bootcamp.path.Run
 import com.google.android.gms.maps.model.LatLng
@@ -53,7 +53,6 @@ class CommunityFragment : Fragment(R.layout.fragment_community) {
         createSortButton(view)
 
         createBackButton(view)
-
     }
 
     /**
@@ -127,6 +126,7 @@ class CommunityFragment : Fragment(R.layout.fragment_community) {
      */
     private fun createNavigationMenu(view: View) {
         val menu = view.findViewById<NavigationView>(R.id.community_navigation_view).menu
+        createTournamentButton(menu)
 
         val weekly = menu.addSubMenu("Weekly tournament")
         createMenuItem(view, weekly, tournament.getWeeklyTournament())
@@ -139,6 +139,15 @@ class CommunityFragment : Fragment(R.layout.fragment_community) {
         for (t in tournament.getDiscoverTournament("placeholder")) {
             createMenuItem(view, discover, t)
         }
+    }
+
+    private fun createTournamentButton(menu: Menu) {
+        menu.add("Create new tournament")
+            .setIcon(R.drawable.ic_add)
+            .setOnMenuItemClickListener {
+                replaceFragment<TournamentCreationFragment>()
+                true
+            }
     }
 
     /**
@@ -199,6 +208,16 @@ class CommunityFragment : Fragment(R.layout.fragment_community) {
         list.addAll(tournament.getYourTournament("placeholder"))
         list.addAll(tournament.getDiscoverTournament("placeholder"))
         return list
+    }
+
+    /**
+     * replace this fragment by another one
+     */
+    private inline fun <reified F : Fragment> replaceFragment() {
+        activity?.supportFragmentManager?.commit {
+            setReorderingAllowed(true)
+            replace<F>(R.id.fragmentContainerView)
+        }
     }
 
     //TODO replace by real tournaments

--- a/app/src/main/res/drawable/ic_add.xml
+++ b/app/src/main/res/drawable/ic_add.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="?attr/colorControlNormal"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_tournament_creation.xml
+++ b/app/src/main/res/layout/fragment_tournament_creation.xml
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <ImageButton
+            android:id="@+id/tournament_creation_back_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start|center"
+            android:backgroundTint="@color/fui_transparent"
+            android:contentDescription="@string/back"
+            android:src="@drawable/ic_arrow_back" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginHorizontal="5dp"
+            android:text="@string/tournament_creation"
+            android:textSize="22sp" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="10dp"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="18sp"
+            android:layout_marginVertical="5dp"
+            android:text="Choose the title"/>
+
+        <EditText
+            android:id="@+id/tournament_creation_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="5dp"
+            android:background="@drawable/customborder"
+            android:hint="Tournament title" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="18sp"
+            android:layout_marginVertical="5dp"
+            android:text="Choose the description"/>
+
+
+        <EditText
+            android:id="@+id/tournament_creation_description"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:lines="3"
+            android:layout_marginBottom="5dp"
+            android:background="@drawable/customborder"
+            android:hint="Tournament description" />
+
+        <TextView
+            android:layout_marginTop="5dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="18sp"
+            android:layout_marginVertical="5dp"
+            android:text="Select the starting date and time" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="5dp"
+            android:orientation="horizontal">
+
+            <Space
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
+
+            <TextView
+                android:id="@+id/tournament_creation_start_date"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="16sp"
+                android:layout_marginHorizontal="10dp"
+                android:text="12/12/22" />
+
+            <TextView
+                android:id="@+id/tournament_creation_start_time"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="16sp"
+                android:layout_marginHorizontal="10dp"
+                android:text="11:12" />
+
+            <Space
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
+
+        </LinearLayout>
+
+        <TextView
+            android:layout_marginTop="5dp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="18sp"
+            android:layout_marginVertical="5dp"
+            android:text="Select the ending date and time" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="5dp"
+            android:orientation="horizontal">
+
+            <Space
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
+
+            <TextView
+                android:id="@+id/tournament_creation_end_date"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="16sp"
+                android:layout_marginHorizontal="10dp"
+                android:text="12/12/22" />
+
+            <TextView
+                android:id="@+id/tournament_creation_end_time"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="16sp"
+                android:layout_marginHorizontal="10dp"
+                android:text="11:12" />
+
+            <Space
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
+
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="18sp"
+            android:layout_marginVertical="5dp"
+            android:text="Select the visibility" />
+
+        <RadioGroup
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <RadioButton
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layoutDirection="rtl"
+                android:text="friends only" />
+
+            <RadioButton
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layoutDirection="rtl"
+                android:text="public" />
+
+        </RadioGroup>
+
+        <Space
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
+        <Button
+            android:id="@+id/tournament_creation_create_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="Create" />
+
+    </LinearLayout>
+
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_tournament_creation.xml
+++ b/app/src/main/res/layout/fragment_tournament_creation.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:id="@+id/tournament_creation_fragment"
     android:orientation="vertical">
 
     <LinearLayout

--- a/app/src/main/res/layout/fragment_tournament_creation.xml
+++ b/app/src/main/res/layout/fragment_tournament_creation.xml
@@ -28,167 +28,210 @@
 
     </LinearLayout>
 
-    <LinearLayout
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_margin="10dp"
-        android:orientation="vertical">
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="18sp"
-            android:layout_marginVertical="5dp"
-            android:text="Choose the title"/>
-
-        <EditText
-            android:id="@+id/tournament_creation_title"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="5dp"
-            android:background="@drawable/customborder"
-            android:hint="Tournament title" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="18sp"
-            android:layout_marginVertical="5dp"
-            android:text="Choose the description"/>
-
-
-        <EditText
-            android:id="@+id/tournament_creation_description"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:lines="3"
-            android:layout_marginBottom="5dp"
-            android:background="@drawable/customborder"
-            android:hint="Tournament description" />
-
-        <TextView
-            android:layout_marginTop="5dp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="18sp"
-            android:layout_marginVertical="5dp"
-            android:text="Select the starting date and time" />
+        android:layout_height="wrap_content">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="5dp"
-            android:orientation="horizontal">
-
-            <Space
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                android:layout_weight="1" />
-
-            <TextView
-                android:id="@+id/tournament_creation_start_date"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textSize="16sp"
-                android:layout_marginHorizontal="10dp"
-                android:text="12/12/22" />
-
-            <TextView
-                android:id="@+id/tournament_creation_start_time"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textSize="16sp"
-                android:layout_marginHorizontal="10dp"
-                android:text="11:12" />
-
-            <Space
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                android:layout_weight="1" />
-
-        </LinearLayout>
-
-        <TextView
-            android:layout_marginTop="5dp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="18sp"
-            android:layout_marginVertical="5dp"
-            android:text="Select the ending date and time" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="5dp"
-            android:orientation="horizontal">
-
-            <Space
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                android:layout_weight="1" />
-
-            <TextView
-                android:id="@+id/tournament_creation_end_date"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textSize="16sp"
-                android:layout_marginHorizontal="10dp"
-                android:text="12/12/22" />
-
-            <TextView
-                android:id="@+id/tournament_creation_end_time"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textSize="16sp"
-                android:layout_marginHorizontal="10dp"
-                android:text="11:12" />
-
-            <Space
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                android:layout_weight="1" />
-
-        </LinearLayout>
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="18sp"
-            android:layout_marginVertical="5dp"
-            android:text="Select the visibility" />
-
-        <RadioGroup
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
             android:orientation="vertical">
 
-            <RadioButton
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="5dp"
+                android:text="@string/choose_the_title"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/tournament_creation_title_error"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/red"
+                android:visibility="gone" />
+
+            <EditText
+                android:id="@+id/tournament_creation_title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layoutDirection="rtl"
-                android:text="friends only" />
+                android:layout_marginBottom="5dp"
+                android:background="@drawable/customborder"
+                android:hint="@string/tournament_title"
+                android:inputType="text" />
 
-            <RadioButton
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="5dp"
+                android:text="@string/choose_the_description"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/tournament_creation_description_error"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/red"
+                android:visibility="gone" />
+
+
+            <EditText
+                android:id="@+id/tournament_creation_description"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layoutDirection="rtl"
-                android:text="public" />
+                android:layout_marginBottom="5dp"
+                android:background="@drawable/customborder"
+                android:hint="@string/tournament_description"
+                android:inputType="textMultiLine"
+                android:lines="3" />
 
-        </RadioGroup>
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="5dp"
+                android:layout_marginTop="5dp"
+                android:text="@string/select_the_starting_date_and_time"
+                android:textSize="18sp" />
 
-        <Space
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_weight="1" />
+            <TextView
+                android:id="@+id/tournament_creation_start_date_error"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/red"
+                android:visibility="gone" />
 
-        <Button
-            android:id="@+id/tournament_creation_create_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:text="Create" />
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="5dp"
+                android:orientation="horizontal">
 
-    </LinearLayout>
+                <Space
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:layout_weight="1" />
 
+                <TextView
+                    android:id="@+id/tournament_creation_start_date"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="10dp"
+                    android:clickable="true"
+                    android:textSize="18sp" />
+
+                <TextView
+                    android:id="@+id/tournament_creation_start_time"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="10dp"
+                    android:clickable="true"
+                    android:textSize="18sp" />
+
+                <Space
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:layout_weight="1" />
+
+            </LinearLayout>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="5dp"
+                android:layout_marginTop="5dp"
+                android:text="@string/select_the_ending_date_and_time"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/tournament_creation_end_date_error"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/red"
+                android:visibility="gone" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="5dp"
+                android:orientation="horizontal">
+
+                <Space
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:layout_weight="1" />
+
+                <TextView
+                    android:id="@+id/tournament_creation_end_date"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="10dp"
+                    android:clickable="true"
+                    android:textSize="18sp" />
+
+                <TextView
+                    android:id="@+id/tournament_creation_end_time"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="10dp"
+                    android:clickable="true"
+                    android:textSize="18sp" />
+
+                <Space
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:layout_weight="1" />
+
+            </LinearLayout>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="5dp"
+                android:text="@string/select_the_visibility"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/tournament_creation_visibility_error"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/red"
+                android:visibility="gone" />
+
+            <RadioGroup
+                android:id="@+id/tournament_creation_visibility"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <RadioButton
+                    android:id="@+id/tournament_creation_visibility_item_0"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layoutDirection="rtl" />
+
+                <RadioButton
+                    android:id="@+id/tournament_creation_visibility_item_1"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layoutDirection="rtl" />
+
+            </RadioGroup>
+
+            <Button
+                android:id="@+id/tournament_creation_create_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:paddingVertical="5dp"
+                android:text="@string/create" />
+
+            <!--trick to display the create button a bit higher when scrolling is needed-->
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
+    </ScrollView>
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,4 +78,10 @@
     <string name="public_visibility">Public</string>
     <string name="friends_only">Friends only</string>
     <string name="create">Create</string>
+    <string name="tournament_creation_title_error">* Title should not be empty</string>
+    <string name="tournament_creation_description_error">* Description should not be empty</string>
+    <string name="tournament_creation_start_date_error">* Starting time and date should be at least 1 hour from now</string>
+    <string name="tournament_creation_end_date_error">* Ending time and date should be at least 1 day from starting day and time</string>
+    <string name="tournament_creation_visibility_error">* One visibility option should be checked</string>
+    <string name="create_new_tournament">Create new tournament</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,4 +68,14 @@
     <string name="back">back</string>
     <string name="home">Home</string>
     <string name="tournament_creation">Tournament Creation</string>
+    <string name="choose_the_title">Choose the title</string>
+    <string name="tournament_title">Tournament title</string>
+    <string name="choose_the_description">Choose the description</string>
+    <string name="tournament_description">Tournament description</string>
+    <string name="select_the_starting_date_and_time">Select the starting date and time</string>
+    <string name="select_the_ending_date_and_time">Select the ending date and time</string>
+    <string name="select_the_visibility">Select the visibility</string>
+    <string name="public_visibility">Public</string>
+    <string name="friends_only">Friends only</string>
+    <string name="create">Create</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,4 +67,5 @@
     <string name="downvote">downvote</string>
     <string name="back">back</string>
     <string name="home">Home</string>
+    <string name="tournament_creation">Tournament Creation</string>
 </resources>


### PR DESCRIPTION
this PR adds the UI for creating a tournament (it does not store it for now)

Here is the access to the tournament creation from the menu button located at the top left of the community fragment.

<img width="373" alt="image" src="https://user-images.githubusercontent.com/61149724/228678765-d495df06-f596-4681-934a-2ff2a3161f02.png">

On the tournament creation page, you can select the title, the description, the starting date and time via a date picker and a time picker, the ending date and time also with pickers and choose the visibility of the tournaments either friends only or public.

<img width="373" alt="image" src="https://user-images.githubusercontent.com/61149724/228679016-581fa970-b344-4943-97d2-ae1f1628515b.png">

closes #57