### PR TITLE
92 modify username

### DIFF
--- a/app/src/androidTest/java/com/epfl/drawyourpath/preferences/PreferencesFragmentTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/preferences/PreferencesFragmentTest.kt
@@ -1,8 +1,14 @@
 package com.epfl.drawyourpath.preferences
 
+import android.content.Intent
+import android.os.Bundle
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
@@ -10,10 +16,13 @@ import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.runner.lifecycle.ApplicationLifecycleCallback
 import com.epfl.drawyourpath.R
 import com.epfl.drawyourpath.login.ENABLE_ONETAP_SIGNIN
 import com.epfl.drawyourpath.login.LoginActivity
+import com.epfl.drawyourpath.userProfileCreation.UserProfileCreationActivity
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -29,6 +38,150 @@ class PreferencesFragmentTest {
                 hasDescendant(withText(preferenceTitle)), click()
             )
         )
+    }
+    //--------------- Modify Username ---------------
+
+    /**
+     * Test if clicking on modify password on the preference menu show the fragment to modify the password
+     */
+    @Test
+    fun clickingOnModifyUsernameDisplaysModifyUsernameFragment(){
+        val scenario = launchFragmentInContainer<PreferencesFragment>(themeResId = R.style.Theme_Bootcamp)
+
+        clickOnPreference("Modify username")
+
+        //Check that the fragment to modify the password is displayed
+        onView(withId(R.id.fragment_modify_username)).check(matches(isDisplayed()))
+
+        scenario.close()
+    }
+
+    /**
+     * Test if the correct message is output below the TEST AVAILABILITY button,
+     * when we click on the TEST AVAILABILITY button
+     * when the username was already taken by another user.
+     */
+    @Test
+    fun usernameUnAvailableIsPrintUnAvailableModifyUsername() {
+        //pass in test mode to used the Mockdatabase instead of the Firebase
+        val bundle: Bundle = Bundle()
+        bundle.putBoolean("isRunningTestForDataBase", true)
+        val scenario = launchFragmentInContainer<ModifyUsernameFragment>(fragmentArgs = bundle, themeResId = R.style.Theme_Bootcamp)
+
+        onView(withId(R.id.input_username_modify_username)).perform(ViewActions.typeText("albert"))
+        Espresso.closeSoftKeyboard()
+        onView(withId(R.id.test_availability_modify_username)).perform(ViewActions.click())
+
+        //test if the text printed is correct
+        onView(withId(R.id.error_text_modify_username)).check(matches(withText("*The username albert is NOT available or equal to the previous one")))
+
+        scenario.close()
+    }
+
+    /**
+     * Test if the correct message is output below the TEST AVAILABILITY button,
+     * when we click on the TEST AVAILABILITY button
+     * when the user name is empty in the edit view.
+     */
+    @Test
+    fun usernameUnAvailableIsPrintIncorrectWhenWeChooseAnEmptyUsernameModifyUsername() {
+        //pass in test mode to used the Mockdatabase instead of the Firebase
+        val bundle: Bundle = Bundle()
+        bundle.putBoolean("isRunningTestForDataBase", true)
+        val scenario = launchFragmentInContainer<ModifyUsernameFragment>(fragmentArgs = bundle, themeResId = R.style.Theme_Bootcamp)
+
+        onView(withId(R.id.test_availability_modify_username)).perform(ViewActions.click())
+
+        //test if the text printed is correct
+        onView(withId(R.id.error_text_modify_username)).check(matches(withText("The username can't be empty !")))
+
+        scenario.close()
+    }
+
+    /**
+     * Test if the correct message is output below the TEST AVAILABILITY button,
+     * when we click on the TEST AVAILABILITY button
+     * when the user name is available in the edit view.
+     */
+    @Test
+    fun usernameCorrectIsPrintCorrectModifyUsername() {
+        //pass in test mode to used the Mockdatabase instead of the Firebase
+        val bundle: Bundle = Bundle()
+        bundle.putBoolean("isRunningTestForDataBase", true)
+        val scenario = launchFragmentInContainer<ModifyUsernameFragment>(fragmentArgs = bundle, themeResId = R.style.Theme_Bootcamp)
+
+        onView(withId(R.id.input_username_modify_username)).perform(ViewActions.typeText("hugo"))
+        Espresso.closeSoftKeyboard()
+        onView(withId(R.id.test_availability_modify_username)).perform(ViewActions.click())
+
+        //test if the text printed is correct
+        onView(withId(R.id.error_text_modify_username)).check(matches(withText("*The username hugo is available")))
+
+        scenario.close()
+    }
+
+    /**
+     * Test that click on VALIDATE button if the username is unavailable
+     * will show the message that this username is unavailable
+     */
+    @Test
+    fun validateAnUnAvailableUserNameShowMessageModifyUsername() {
+        //pass in test mode to used the Mockdatabase instead of the Firebase
+        val bundle: Bundle = Bundle()
+        bundle.putBoolean("isRunningTestForDataBase", true)
+        val scenario = launchFragmentInContainer<ModifyUsernameFragment>(fragmentArgs = bundle, themeResId = R.style.Theme_Bootcamp)
+
+        onView(withId(R.id.input_username_modify_username)).perform(ViewActions.typeText("albert"))
+        Espresso.closeSoftKeyboard()
+        onView(withId(R.id.validate_modify_username)).perform(ViewActions.click())
+
+        //test if the text printed is correct
+        onView(withId(R.id.error_text_modify_username)).check(matches(withText("*The username albert is NOT available or equal to the previous one")))
+
+        scenario.close()
+    }
+
+    /**
+     * Test that click on VALIDATE button if the username is unavailable
+     * will show the message that this username is unavailable
+     */
+    @Test
+    fun validateAnEmptyUserNameShowMessageModifyUsername() {
+        //pass in test mode to used the Mockdatabase instead of the Firebase
+        val bundle: Bundle = Bundle()
+        bundle.putBoolean("isRunningTestForDataBase", true)
+        val scenario = launchFragmentInContainer<ModifyUsernameFragment>(fragmentArgs = bundle, themeResId = R.style.Theme_Bootcamp)
+
+        onView(withId(R.id.validate_modify_username)).perform(ViewActions.click())
+
+        //test if the text printed is correct
+        onView(withId(R.id.error_text_modify_username)).check(matches(withText("The username can't be empty !")))
+
+        scenario.close()
+    }
+
+    /**
+     * Test that we pass to the next correct fragment after we click on the cancel button
+     * is correct
+     */
+    @Test
+    fun correctTransitionCancelModifyUsername() {
+        //pass in test mode to used the Mockdatabase instead of the Firebase
+        val bundle: Bundle = Bundle()
+        bundle.putBoolean("isRunningTestForDataBase", true)
+        val scenario = launchFragmentInContainer<PreferencesFragment>(fragmentArgs = bundle, themeResId = R.style.Theme_Bootcamp)
+
+        clickOnPreference("Modify username")
+
+        onView(withId(R.id.cancel_modify_username))
+            .perform(ViewActions.click())
+
+        //test if the correct fragment is show after clicking on VALIDATE button
+        // Check fragment is settings
+        // see https://stackoverflow.com/questions/45172505/testing-android-preferencefragment-with-espresso
+        onView(withId(androidx.preference.R.id.recycler_view)).check(matches(isDisplayed()))
+
+        scenario.close()
     }
 
     //--------------- Modify Password ---------------

--- a/app/src/main/java/com/epfl/drawyourpath/database/FireDatabase.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/FireDatabase.kt
@@ -88,7 +88,7 @@ class FireDatabase : Database() {
                     //update the link username to userId and the username on the userAccount
                     setUsername(username).thenAccept { isSetUsername ->
                         if (isSetUsername) {
-                            future.thenApply { removeUsernameToUidMapping(username) }
+                            removeUsernameToUidMapping(pastUsername, future)
                         } else {
                             future.completeExceptionally(java.lang.Error("Impossible to set this username !"))
                         }
@@ -260,10 +260,10 @@ class FireDatabase : Database() {
     /**
      * Helper function to remove the past link from username->userId
      * @param username that will be removed form the mapping
+     * @param future future state before the execution of this function
      * @return a future that indicate if the username was correctly removed
      */
-    private fun removeUsernameToUidMapping(username: String) {
-        val future = CompletableFuture<Boolean>()
+    private fun removeUsernameToUidMapping(username: String, future: CompletableFuture<Boolean>) {
         //remove the past username from the link username/userId
         accessUsernameToUserIdFile().child(username).removeValue()
             .addOnSuccessListener { future.complete(true) }

--- a/app/src/main/java/com/epfl/drawyourpath/preferences/ModifyUsernameFragment.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/preferences/ModifyUsernameFragment.kt
@@ -1,0 +1,119 @@
+package com.epfl.drawyourpath.preferences
+
+import android.graphics.Color
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.View
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+import com.epfl.drawyourpath.R
+import com.epfl.drawyourpath.database.Database
+import com.epfl.drawyourpath.database.FireDatabase
+import com.epfl.drawyourpath.database.MockDataBase
+import java.util.concurrent.CompletableFuture
+
+class ModifyUsernameFragment : Fragment(R.layout.fragment_modify_username) {
+
+    private var isTest: Boolean = false
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        var database: Database = FireDatabase()
+
+        //retrieve the value from the welcome activity to know if we are running testes
+        val isRunTest: Bundle? = arguments
+        if (isRunTest == null) {
+            isTest = false
+        } else {
+            isTest = isRunTest.getBoolean("isRunningTestForDataBase")
+        }
+
+        //select the correct database in function of test scenario
+        if (isTest) {
+            database = MockDataBase()
+        }
+
+        //retrieve the different elements of the UI
+        val testUserNameButton: Button =
+            view.findViewById(R.id.test_availability_modify_username)
+        val inputUserName: EditText =
+            view.findViewById(R.id.input_username_modify_username)
+        val errorMessageText: TextView = view.findViewById(R.id.error_text_modify_username)
+        val cancelButton: Button = view.findViewById(R.id.cancel_modify_username)
+        val validateButton: Button = view.findViewById(R.id.validate_modify_username)
+
+        testUserNameButton.setOnClickListener {
+            testUsernameAvailability(database, inputUserName.text.toString(), errorMessageText)
+        }
+
+        //set the username if it is correct when clicking on the validate button and return back to the preferences if it is updated
+        validateButton.setOnClickListener {
+            validateButtonAction(inputUserName.text.toString(), database, errorMessageText)
+        }
+
+        //return back to preferences if click on cancel button without modifying the username
+        cancelButton.setOnClickListener{
+            returnBackToPreviousFrag()
+        }
+    }
+    /**
+     * Helper function to test if the username can be update in the database and if if it is the case return to the preferences fragment.
+     * @param username that we want to test and potentially set to the database
+     * @param database used to store the user information
+     * @param errorMessage text view to display the potential error message to the user
+     */
+    private fun validateButtonAction(username: String, database: Database, errorMessage: TextView){
+        val testUsername = testUsernameAvailability(database, username, errorMessage)
+        testUsername.thenAccept{available ->
+            if(available){
+                database.updateUsername(username).thenAccept{usernameSet ->
+                    if(usernameSet){
+                        returnBackToPreviousFrag()
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Helper function to return back to the previous fragment
+     */
+    private fun returnBackToPreviousFrag(){
+        activity?.onBackPressed()
+    }
+}
+
+/**
+ * Helper function that display a message with outputMessage to the user on the UI and return a boolean that indicate
+ * if the username is available and not equal to the previous username that user have.
+ * @param username username with the availability to test
+ * @param database used to test if the username is available
+ * @param errorMessage editText used to show an error message to the user on the UI if the username is not available
+ * @return true if the username is available or not equal to the previous one, and false otherwise
+ */
+private fun testUsernameAvailability(
+    database: Database,
+    username: String,
+    errorMessage: TextView
+): CompletableFuture<Boolean> {
+    if (username == "") {
+        errorMessage.text = buildString { append("The username can't be empty !") }
+        errorMessage.setTextColor(Color.RED)
+        return CompletableFuture.completedFuture(false)
+    }
+    val future = database.isUsernameAvailable(username)
+
+    val durationFuture = future.thenApply {
+        errorMessage.text = buildString {
+            append("*The username ")
+            append(username)
+            append(" is ")
+            append(if (!it) "NOT " else "")
+            append("available")
+            append(if (!it) "or equal to the previous one" else "")
+        }
+        errorMessage.setTextColor(if (it) Color.GREEN else Color.RED)
+        it
+    }
+    return durationFuture
+}

--- a/app/src/main/java/com/epfl/drawyourpath/preferences/ModifyUsernameFragment.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/preferences/ModifyUsernameFragment.kt
@@ -110,7 +110,7 @@ private fun testUsernameAvailability(
             append(" is ")
             append(if (!it) "NOT " else "")
             append("available")
-            append(if (!it) "or equal to the previous one" else "")
+            append(if (!it) " or equal to the previous one" else "")
         }
         errorMessage.setTextColor(if (it) Color.GREEN else Color.RED)
         it

--- a/app/src/main/res/layout/fragment_modify_username.xml
+++ b/app/src/main/res/layout/fragment_modify_username.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/fragment_modify_username"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/choose_your_new_username"
+        android:textSize="20sp"
+        android:layout_marginStart="10dp" />
+    <Space
+        android:layout_width="match_parent"
+        android:layout_height="30sp" />
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:justificationMode="inter_word"
+        android:padding="4dp"
+        android:text="@string/explication_text_username_init"
+        android:textIsSelectable="false"
+        android:textSize="15sp" />
+
+    <EditText
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:layout_marginEnd="10dp"
+        android:hint="@string/user_name"
+        android:textSize="20sp"
+        android:id="@+id/input_username_modify_username"/>
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="left"
+        android:layout_marginLeft="40dp"
+        android:textSize="20dp"
+        android:id="@+id/error_text_modify_username"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="50dp"
+            android:text="@string/test_availability"
+            android:id="@+id/test_availability_modify_username"/>
+
+    </LinearLayout>
+
+    <Space
+        android:layout_width="match_parent"
+        android:layout_height="40sp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="50dp"
+            android:text="@string/cancel"
+            android:id="@+id/cancel_modify_username"/>
+
+        <Space
+            android:layout_width="40dp"
+            android:layout_height="match_parent" />
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="50dp"
+            android:text="@string/validate"
+            android:id="@+id/validate_modify_username"/>
+
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,4 +91,5 @@
     <string name="tournament_creation_end_date_error">* Ending time and date should be at least 1 day from starting day and time</string>
     <string name="tournament_creation_visibility_error">* One visibility option should be checked</string>
     <string name="create_new_tournament">Create new tournament</string>
+    <string name="choose_your_new_username">Choose your new username :</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -18,10 +18,10 @@
         app:key="account_category"
         app:title="Account">
 
-        <EditTextPreference
+        <Preference
+            app:fragment="com.epfl.drawyourpath.preferences.ModifyUsernameFragment"
             app:key="modify_username"
-            app:title="Modify username"
-            app:useSimpleSummaryProvider="true" />
+            app:title="Modify username" />
 
         <Preference
             app:fragment="com.epfl.drawyourpath.preferences.ModifyPasswordFragment"


### PR DESCRIPTION
This PR contains a fragment in the preferences to modify the username of the user. To be updated, the new username must be available in the database and not equal to the previous one. This fragment contins a button to test the availability of a given username, a button to cancel the update of the username and a button to validate the update of the username(with check).
Thank you in advance for your review. 
Don't hesitate if you have any questions. 
<img width="257" alt="Capture d’écran 2023-04-12 à 17 08 06" src="https://user-images.githubusercontent.com/79543688/231500978-bf6252e5-5ead-4f27-95f5-006c9ecec9b5.png">

Close(#92 )