### PR TITLE
102 modify profile photo

### DIFF
--- a/app/src/androidTest/java/com/epfl/drawyourpath/preferences/PreferencesFragmentTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/preferences/PreferencesFragmentTest.kt
@@ -82,6 +82,8 @@ class PreferencesFragmentTest {
         val scenario = launchFragmentInContainer<ModifyProfilePhotoFragment>(fragmentArgs = bundle, themeResId = R.style.Theme_Bootcamp)
 
         onView(withId(R.id.photo_description_modify_profile_photo)).check(matches(withText(R.string.actual_profile_photo)))
+
+        scenario.close()
     }
 
     /**
@@ -95,6 +97,8 @@ class PreferencesFragmentTest {
         val scenario = launchFragmentInContainer<ModifyProfilePhotoFragment>(fragmentArgs = bundle, themeResId = R.style.Theme_Bootcamp)
 
         onView(withId(R.id.photo_modify_profile_photo)).check(matches(withTagValue(equalTo( R.drawable.profile_placholderpng))))
+
+        scenario.close()
     }
 
     /**
@@ -110,6 +114,8 @@ class PreferencesFragmentTest {
         onView(withId(R.id.select_photo_modify_profile_photo)).perform(click())
 
         onView(withId(R.id.photo_modify_profile_photo)).check(matches(withTagValue(equalTo(photoSelectedInPicker.byteCount))))
+
+        scenario.close()
     }
 
     /**
@@ -125,6 +131,8 @@ class PreferencesFragmentTest {
         onView(withId(R.id.select_photo_modify_profile_photo)).perform(click())
 
         onView(withId(R.id.photo_description_modify_profile_photo)).check(matches(withText(R.string.new_profile_photo_selected)))
+
+        scenario.close()
     }
 
     /**

--- a/app/src/androidTest/java/com/epfl/drawyourpath/preferences/PreferencesFragmentTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/preferences/PreferencesFragmentTest.kt
@@ -1,5 +1,7 @@
 package com.epfl.drawyourpath.preferences
 
+import android.graphics.Bitmap
+import android.os.Bundle
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import androidx.test.espresso.Espresso.onView
@@ -14,12 +16,16 @@ import androidx.test.espresso.matcher.ViewMatchers.*
 import com.epfl.drawyourpath.R
 import com.epfl.drawyourpath.login.ENABLE_ONETAP_SIGNIN
 import com.epfl.drawyourpath.login.LoginActivity
+import org.hamcrest.CoreMatchers.equalTo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class PreferencesFragmentTest {
+
+    //for the test of the profile photo modification
+    private val photoSelectedInPicker : Bitmap = Bitmap.createBitmap(8,5, Bitmap.Config.RGB_565)
 
     //Note: testing the preference screen is not very convenient:
     //https://stackoverflow.com/questions/45172505/testing-android-preferencefragment-with-espresso
@@ -30,6 +36,179 @@ class PreferencesFragmentTest {
             )
         )
     }
+    //--------------- Modify Profile Photo ---------------
+    /**
+     * Test if clicking on modify profile photo on the preferences menu show the fragment to modify the profile photo
+     */
+    @Test
+    fun clickingOnModifyProfilePhotoShowModifyProfilePhotoFragment(){
+        val scenario = launchFragmentInContainer<PreferencesFragment>(themeResId = R.style.Theme_Bootcamp)
+
+        clickOnPreference("Modify Profile Photo")
+
+        //check that the fragment that modify the profile photo is displayed
+        onView(withId( R.id.fragment_modify_profile_photo)).check(matches(isDisplayed()))
+
+        scenario.close()
+    }
+
+    /**
+     * Check that click on the cancel button, return back to preferences
+     */
+    @Test
+    fun correctTransitionCancelButtonModifyProfilePhoto(){
+        val scenario = launchFragmentInContainer<PreferencesFragment>(themeResId = R.style.Theme_Bootcamp)
+
+        clickOnPreference("Modify Profile Photo")
+
+        onView(withId(R.id.cancel_modify_profile_photo)).perform(click())
+
+        //check that the fragment of preferences is displayed
+        // Check fragment is settings
+        // see https://stackoverflow.com/questions/45172505/testing-android-preferencefragment-with-espresso
+        onView(withId(androidx.preference.R.id.recycler_view)).check(matches(isDisplayed()))
+
+        scenario.close()
+    }
+
+    /**
+     * Check that the correct description text photo is displayed before selecting a new photo
+     */
+    @Test
+    fun correctDescriptionTextBeforeNewPhotoModifyProfilePhoto(){
+        //pass in test mode to used the Mockdatabase instead of the Firebase
+        val bundle: Bundle = Bundle()
+        bundle.putBoolean("isRunningTestForDataBase", true)
+        val scenario = launchFragmentInContainer<ModifyProfilePhotoFragment>(fragmentArgs = bundle, themeResId = R.style.Theme_Bootcamp)
+
+        onView(withId(R.id.photo_description_modify_profile_photo)).check(matches(withText(R.string.actual_profile_photo)))
+    }
+
+    /**
+     * Check that the correct photo is displayed before selecting a new photo when the user have no profile photo
+     */
+    @Test
+    fun correctDefaultPhotoBeforeNewPhotoModifyProfilePhoto(){
+        //pass in test mode to used the Mockdatabase instead of the Firebase
+        val bundle: Bundle = Bundle()
+        bundle.putBoolean("isRunningTestForDataBase", true)
+        val scenario = launchFragmentInContainer<ModifyProfilePhotoFragment>(fragmentArgs = bundle, themeResId = R.style.Theme_Bootcamp)
+
+        onView(withId(R.id.photo_modify_profile_photo)).check(matches(withTagValue(equalTo( R.drawable.profile_placholderpng))))
+    }
+
+    /**
+     * Check that the correct photo is displayed after selecting a new photo
+     */
+    @Test
+    fun correctPhotoAfterNewPhotoModifyProfilePhoto(){
+        //pass in test mode to used the Mockdatabase instead of the Firebase
+        val bundle: Bundle = Bundle()
+        bundle.putBoolean("isRunningTestForDataBase", true)
+        val scenario = launchFragmentInContainer<ModifyProfilePhotoFragment>(fragmentArgs = bundle, themeResId = R.style.Theme_Bootcamp)
+
+        onView(withId(R.id.select_photo_modify_profile_photo)).perform(click())
+
+        onView(withId(R.id.photo_modify_profile_photo)).check(matches(withTagValue(equalTo(photoSelectedInPicker.byteCount))))
+    }
+
+    /**
+     * Check that the correct description text photo is displayed after selecting a new photo
+     */
+    @Test
+    fun correctDescriptionTextAfterNewPhotoModifyProfilePhoto(){
+        //pass in test mode to used the Mockdatabase instead of the Firebase
+        val bundle: Bundle = Bundle()
+        bundle.putBoolean("isRunningTestForDataBase", true)
+        val scenario = launchFragmentInContainer<ModifyProfilePhotoFragment>(fragmentArgs = bundle, themeResId = R.style.Theme_Bootcamp)
+
+        onView(withId(R.id.select_photo_modify_profile_photo)).perform(click())
+
+        onView(withId(R.id.photo_description_modify_profile_photo)).check(matches(withText(R.string.new_profile_photo_selected)))
+    }
+
+    /**
+     * Test if the correct error message is output below the "Select a photo" buttom,
+     * when we click on the "VALIDATE" button
+     * when the user forgot to select a photo
+     */
+    @Test
+    fun errorPrintedWhenValidateNotModifyPhoto() {
+        //pass in test mode to used the Mockdatabase instead of the Firebase
+        val bundle: Bundle = Bundle()
+        bundle.putBoolean("isRunningTestForDataBase", true)
+        val scenario = launchFragmentInContainer<ModifyProfilePhotoFragment>(fragmentArgs = bundle, themeResId = R.style.Theme_Bootcamp)
+
+        onView(withId(R.id.validate_modify_profile_photo))
+            .perform(click())
+
+        //test if the text printed is correct
+        onView(withId(R.id.error_modify_profile_photo)).check(matches(withText(R.string.error_select_new_profile_photo)))
+
+        scenario.close()
+    }
+
+    /**
+     * Test if no transition occur in fragment
+     * when we click on the "VALIDATE" button
+     * when the user forgot to select a photo
+     */
+    @Test
+    fun noTransitionWhenValidateNotModifyPhoto() {
+        //pass in test mode to used the Mockdatabase instead of the Firebase
+        val bundle: Bundle = Bundle()
+        bundle.putBoolean("isRunningTestForDataBase", true)
+        val scenario = launchFragmentInContainer<ModifyProfilePhotoFragment>(fragmentArgs = bundle, themeResId = R.style.Theme_Bootcamp)
+
+        onView(withId(R.id.validate_modify_profile_photo))
+            .perform(click())
+
+        //test if the text printed is correct
+        onView(withId(R.id.fragment_modify_profile_photo)).check(matches(isDisplayed()))
+
+        scenario.close()
+    }
+
+    /**
+     * Test if no error message is output below the "Select a photo" button,
+     * at the initial state
+     */
+    @Test
+    fun noErrorInitModifyPhoto() {
+        //pass in test mode to used the Mockdatabase instead of the Firebase
+        val bundle: Bundle = Bundle()
+        bundle.putBoolean("isRunningTestForDataBase", true)
+        val scenario = launchFragmentInContainer<ModifyProfilePhotoFragment>(fragmentArgs = bundle, themeResId = R.style.Theme_Bootcamp)
+
+        //test if the text printed is correct
+        onView(withId(R.id.error_modify_profile_photo)).check(matches(withText("")))
+
+        scenario.close()
+    }
+    /**
+     * Test if no error message is output below the "Select a photo" buttom,
+     * when we click on the "VALIDATE" button
+     * when the user select a photo after forgot to select a photo
+     */
+    @Test
+    fun noErrorWhenSelectPhotoModifyPhoto() {
+        //pass in test mode to used the Mockdatabase instead of the Firebase
+        val bundle: Bundle = Bundle()
+        bundle.putBoolean("isRunningTestForDataBase", true)
+        val scenario = launchFragmentInContainer<ModifyProfilePhotoFragment>(fragmentArgs = bundle, themeResId = R.style.Theme_Bootcamp)
+
+        //validate to display an error message
+        onView(withId(R.id.validate_modify_profile_photo)).perform(click())
+
+        onView(withId(R.id.select_photo_modify_profile_photo))
+            .perform(click())
+
+        //test if the text printed is correct(=error message disappear)
+        onView(withId(R.id.error_modify_profile_photo)).check(matches(withText("")))
+
+        scenario.close()
+    }
+
 
     //--------------- Modify Password ---------------
 

--- a/app/src/main/java/com/epfl/drawyourpath/preferences/ModifyProfilePhotoFragment.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/preferences/ModifyProfilePhotoFragment.kt
@@ -10,14 +10,12 @@ import android.provider.MediaStore
 import androidx.fragment.app.Fragment
 import android.view.View
 import android.widget.Button
-import android.widget.EditText
 import android.widget.ImageView
 import android.widget.TextView
 import com.epfl.drawyourpath.R
 import com.epfl.drawyourpath.database.Database
 import com.epfl.drawyourpath.database.FireDatabase
 import com.epfl.drawyourpath.database.MockDataBase
-import java.util.concurrent.CompletableFuture
 
 class ModifyProfilePhotoFragment : Fragment(R.layout.fragment_modify_profile_photo) {
     //for the test

--- a/app/src/main/java/com/epfl/drawyourpath/preferences/ModifyProfilePhotoFragment.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/preferences/ModifyProfilePhotoFragment.kt
@@ -21,7 +21,7 @@ import java.util.concurrent.CompletableFuture
 
 class ModifyProfilePhotoFragment : Fragment(R.layout.fragment_modify_profile_photo) {
     //for the test
-    private val photoProfileTest : Bitmap = Bitmap.createBitmap(14,14, Bitmap.Config.RGB_565)
+    private val photoProfileTest : Bitmap = Bitmap.createBitmap(8,5, Bitmap.Config.RGB_565)
 
     private var isTest: Boolean = false
 
@@ -30,6 +30,8 @@ class ModifyProfilePhotoFragment : Fragment(R.layout.fragment_modify_profile_pho
     private lateinit var photoPreview: ImageView
 
     private lateinit var errorText: TextView
+
+    private lateinit var photoDescription: TextView
 
     private var photoInitiate: Boolean = false
 
@@ -52,7 +54,7 @@ class ModifyProfilePhotoFragment : Fragment(R.layout.fragment_modify_profile_pho
             database = MockDataBase()
         }
         //retrieve the different elements of the UI
-        val photoDescription: TextView = view.findViewById(R.id.photo_description_modify_profile_photo)
+        photoDescription = view.findViewById(R.id.photo_description_modify_profile_photo)
         errorText = view.findViewById(R.id.error_modify_profile_photo)
         photoPreview = view.findViewById(R.id.photo_modify_profile_photo)
         val selectPhotoButton: Button = view.findViewById(R.id.select_photo_modify_profile_photo)
@@ -66,8 +68,6 @@ class ModifyProfilePhotoFragment : Fragment(R.layout.fragment_modify_profile_pho
 
         //create the photo picker
         createSelectPhotoButton(selectPhotoButton, isTest)
-
-        actualizePhotoDescription(photoDescription)
 
         //return back to preferences if click on cancel button without modifying the username
         cancelButton.setOnClickListener{
@@ -89,19 +89,7 @@ class ModifyProfilePhotoFragment : Fragment(R.layout.fragment_modify_profile_pho
                     ImageDecoder.createSource(requireActivity().contentResolver, imageURI)
                 newProfilePhoto = ImageDecoder.decodeBitmap(sourceURI)
                 photoPreview.setImageBitmap(newProfilePhoto)
-                //remove the error, since a photo has been selected
-                errorText.text = ""
             }
-        }
-    }
-
-    /**
-     * Helper function to set the description text of the photo in function if a new photo has been selected
-     * @param textView where the description will be displayed
-     */
-    private fun actualizePhotoDescription(textView: TextView){
-        if(newProfilePhoto != null){
-            textView.text = getString(R.string.new_profile_photo_selected)
         }
     }
 
@@ -117,6 +105,8 @@ class ModifyProfilePhotoFragment : Fragment(R.layout.fragment_modify_profile_pho
             if(profilePhoto != null){
                 photoPreview.setImageBitmap(profilePhoto)
             }
+            //for the test
+            photoPreview.setTag(R.drawable.profile_placholderpng)
         }
     }
 
@@ -127,6 +117,9 @@ class ModifyProfilePhotoFragment : Fragment(R.layout.fragment_modify_profile_pho
      */
     private fun createSelectPhotoButton(selectButton: Button, isTest: Boolean) {
         selectButton.setOnClickListener {
+            //remove the error, since a photo has been selected
+            errorText.text = ""
+            photoDescription.text = getString(R.string.new_profile_photo_selected)
             if(!isTest){
                 val photoPicker =
                     Intent(Intent.ACTION_PICK, MediaStore.Images.Media.INTERNAL_CONTENT_URI)
@@ -134,6 +127,9 @@ class ModifyProfilePhotoFragment : Fragment(R.layout.fragment_modify_profile_pho
             }else{
                 //affect a simple image in test scenario
                 newProfilePhoto = photoProfileTest
+                photoPreview.setImageBitmap(photoProfileTest)
+                photoPreview.setTag(photoProfileTest.byteCount)
+                photoPreview.setTag(photoProfileTest.byteCount)
             }
         }
     }

--- a/app/src/main/java/com/epfl/drawyourpath/preferences/ModifyProfilePhotoFragment.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/preferences/ModifyProfilePhotoFragment.kt
@@ -1,0 +1,166 @@
+package com.epfl.drawyourpath.preferences
+
+import android.app.Activity
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.ImageDecoder
+import android.os.Bundle
+import android.provider.MediaStore
+import androidx.fragment.app.Fragment
+import android.view.View
+import android.widget.Button
+import android.widget.EditText
+import android.widget.ImageView
+import android.widget.TextView
+import com.epfl.drawyourpath.R
+import com.epfl.drawyourpath.database.Database
+import com.epfl.drawyourpath.database.FireDatabase
+import com.epfl.drawyourpath.database.MockDataBase
+import java.util.concurrent.CompletableFuture
+
+class ModifyProfilePhotoFragment : Fragment(R.layout.fragment_modify_profile_photo) {
+    //for the test
+    private val photoProfileTest : Bitmap = Bitmap.createBitmap(14,14, Bitmap.Config.RGB_565)
+
+    private var isTest: Boolean = false
+
+    private val requestCodeFrag = 100
+
+    private lateinit var photoPreview: ImageView
+
+    private lateinit var errorText: TextView
+
+    private var photoInitiate: Boolean = false
+
+    //new profile photo (=null if no photo selected)
+    private var newProfilePhoto: Bitmap? = null
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        var database: Database = FireDatabase()
+
+        //retrieve the value from the welcome activity to know if we are running testes
+        val isRunTest: Bundle? = arguments
+        if (isRunTest == null) {
+            isTest = false
+        } else {
+            isTest = isRunTest.getBoolean("isRunningTestForDataBase")
+        }
+
+        //select the correct database in function of test scenario
+        if (isTest) {
+            database = MockDataBase()
+        }
+        //retrieve the different elements of the UI
+        val photoDescription: TextView = view.findViewById(R.id.photo_description_modify_profile_photo)
+        errorText = view.findViewById(R.id.error_modify_profile_photo)
+        photoPreview = view.findViewById(R.id.photo_modify_profile_photo)
+        val selectPhotoButton: Button = view.findViewById(R.id.select_photo_modify_profile_photo)
+        val cancelButton: Button = view.findViewById(R.id.cancel_modify_profile_photo)
+        val validateButton: Button = view.findViewById(R.id.validate_modify_profile_photo)
+
+        if(!photoInitiate){
+            initPhotoPreview(photoPreview, database)
+            photoInitiate=true
+        }
+
+        //create the photo picker
+        createSelectPhotoButton(selectPhotoButton, isTest)
+
+        actualizePhotoDescription(photoDescription)
+
+        //return back to preferences if click on cancel button without modifying the username
+        cancelButton.setOnClickListener{
+            returnBackToPreviousFrag()
+        }
+
+        //set the new profile photo(print an error if no new photo have been selected) and go back to the previous fragment
+        validateButton.setOnClickListener{
+            validateButtonAction(newProfilePhoto, database, errorText)
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (resultCode == Activity.RESULT_OK && requestCode == requestCodeFrag) {
+            val imageURI = data?.data
+            if (imageURI != null) {
+                val sourceURI =
+                    ImageDecoder.createSource(requireActivity().contentResolver, imageURI)
+                newProfilePhoto = ImageDecoder.decodeBitmap(sourceURI)
+                photoPreview.setImageBitmap(newProfilePhoto)
+                //remove the error, since a photo has been selected
+                errorText.text = ""
+            }
+        }
+    }
+
+    /**
+     * Helper function to set the description text of the photo in function if a new photo has been selected
+     * @param textView where the description will be displayed
+     */
+    private fun actualizePhotoDescription(textView: TextView){
+        if(newProfilePhoto != null){
+            textView.text = getString(R.string.new_profile_photo_selected)
+        }
+    }
+
+    /**
+     * Helper function to init the photo preview with the actual photo profile and an icon photo if the user don't have one
+     * @param photoPreview photo preview used to display the photo on the UI
+     * @param database used to retrieve the profile photo
+     */
+    private fun initPhotoPreview(photoPreview: ImageView, database: Database){
+        database.getLoggedUserAccount().thenAccept { user->
+            val profilePhoto = user.getProfilePhoto()
+            //we let the default image if the user don't have a profile photo
+            if(profilePhoto != null){
+                photoPreview.setImageBitmap(profilePhoto)
+            }
+        }
+    }
+
+    /**
+     * Helper function to create a photo picker when clicking on select a photo button
+     * @param selectButton button used to lunch the photo picker
+     * @param isTest to know if we are in a test scenario to evict the photo picker view in this case
+     */
+    private fun createSelectPhotoButton(selectButton: Button, isTest: Boolean) {
+        selectButton.setOnClickListener {
+            if(!isTest){
+                val photoPicker =
+                    Intent(Intent.ACTION_PICK, MediaStore.Images.Media.INTERNAL_CONTENT_URI)
+                startActivityForResult(photoPicker, requestCodeFrag)
+            }else{
+                //affect a simple image in test scenario
+                newProfilePhoto = photoProfileTest
+            }
+        }
+    }
+
+    /**
+     * Helper function to set the new profile photo into the database and go back to the previous fragment(display an error message if no new photo have been selected)
+     * @param profilePhoto that we want to set into the database
+     * @param database used to store the user information
+     * @param errorMessage text view to display the potential error message to the user
+     */
+    private fun validateButtonAction(profilePhoto: Bitmap?, database: Database, errorMessage: TextView){
+        if (profilePhoto == null) {
+            errorMessage.text = getString(R.string.error_select_new_profile_photo)
+            errorMessage.setTextColor(Color.RED)
+        } else {
+            database.setProfilePhoto(profilePhoto).thenAccept {isPhotoSet->
+                if (isPhotoSet) {
+                    returnBackToPreviousFrag()
+                }
+            }
+        }
+    }
+
+    /**
+     * Helper function to return back to the previous fragment
+     */
+    private fun returnBackToPreviousFrag(){
+        activity?.onBackPressed()
+    }
+}

--- a/app/src/main/res/layout/fragment_modify_profile_photo.xml
+++ b/app/src/main/res/layout/fragment_modify_profile_photo.xml
@@ -19,7 +19,6 @@
         android:layout_height="wrap_content"
         android:justificationMode="inter_word"
         android:padding="4dp"
-        android:text="@string/modify_profile_photo_description"
         android:textIsSelectable="false"
         android:textSize="15sp" />
 
@@ -38,7 +37,7 @@
         android:layout_width="200dp"
         android:layout_height="200dp"
         android:layout_gravity="center|bottom"
-        android:src="@drawable/profile_placholderpng"/>
+        android:src="@drawable/profile_placholderpng" />
 
     <Button
         android:id="@+id/select_photo_modify_profile_photo"

--- a/app/src/main/res/layout/fragment_modify_profile_photo.xml
+++ b/app/src/main/res/layout/fragment_modify_profile_photo.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/fragment_modify_profile_photo"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/choose_a_new_profile_photo"
+        android:textSize="20sp"
+        android:layout_marginStart="10dp" />
+    <Space
+        android:layout_width="match_parent"
+        android:layout_height="10sp" />
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:justificationMode="inter_word"
+        android:padding="4dp"
+        android:text="@string/modify_profile_photo_description"
+        android:textIsSelectable="false"
+        android:textSize="15sp" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:justificationMode="inter_word"
+        android:padding="4dp"
+        android:text="@string/actual_profile_photo"
+        android:textIsSelectable="false"
+        android:textSize="12dp"
+        android:id="@+id/photo_description_modify_profile_photo"/>
+
+    <ImageView
+        android:id="@+id/photo_modify_profile_photo"
+        android:layout_width="200dp"
+        android:layout_height="200dp"
+        android:layout_gravity="center|bottom"
+        android:src="@drawable/profile_placholderpng"/>
+
+    <Button
+        android:id="@+id/select_photo_modify_profile_photo"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center|bottom"
+        android:text="@string/select_a_photo"
+        android:textSize="20sp" />
+
+    <TextView
+        android:id="@+id/error_modify_profile_photo"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="left"
+        android:layout_marginLeft="40dp"
+        android:textSize="20dp" />
+
+    <Space
+        android:layout_width="match_parent"
+        android:layout_height="10sp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="50dp"
+            android:text="@string/cancel"
+            android:id="@+id/cancel_modify_profile_photo"/>
+
+        <Space
+            android:layout_width="40dp"
+            android:layout_height="match_parent" />
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="50dp"
+            android:text="@string/validate"
+            android:id="@+id/validate_modify_profile_photo"/>
+
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_modify_profile_photo.xml
+++ b/app/src/main/res/layout/fragment_modify_profile_photo.xml
@@ -38,6 +38,7 @@
         android:layout_width="200dp"
         android:layout_height="200dp"
         android:layout_gravity="center|bottom"
+        android:scaleType="centerCrop"
         android:src="@drawable/profile_placholderpng" />
 
     <Button

--- a/app/src/main/res/layout/fragment_modify_profile_photo.xml
+++ b/app/src/main/res/layout/fragment_modify_profile_photo.xml
@@ -19,6 +19,7 @@
         android:layout_height="wrap_content"
         android:justificationMode="inter_word"
         android:padding="4dp"
+        android:text = "@string/modify_profile_photo_description"
         android:textIsSelectable="false"
         android:textSize="15sp" />
 

--- a/app/src/main/res/layout/fragment_photo_profile_init.xml
+++ b/app/src/main/res/layout/fragment_photo_profile_init.xml
@@ -42,6 +42,7 @@
             android:id="@+id/imagePhotoProfileInitFrag"
             android:layout_width="200dp"
             android:layout_height="200dp"
+            android:scaleType="centerCrop"
             android:src="@drawable/profile_placholderpng"
             android:layout_gravity="center|bottom"/>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,5 +95,5 @@
     <string name="modify_profile_photo_description">You can choose a new profile photo and click on VALIDATE to set it. If you want to keep your past profile photo, click on CANCEL.</string>
     <string name="actual_profile_photo">Actual profile photo :</string>
     <string name="new_profile_photo_selected">New profile photo selected :</string>
-    <string name="error_select_new_profile_photo">You have forgot to select a new profile photo.</string>
+    <string name="error_select_new_profile_photo">You have forgotten to select a new profile photo.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,4 +91,9 @@
     <string name="tournament_creation_end_date_error">* Ending time and date should be at least 1 day from starting day and time</string>
     <string name="tournament_creation_visibility_error">* One visibility option should be checked</string>
     <string name="create_new_tournament">Create new tournament</string>
+    <string name="choose_a_new_profile_photo">Choose a new profile photo :</string>
+    <string name="modify_profile_photo_description">You can choose a new profile photo and click on VALIDATE to set it. If you want to keep your past profile photo, click on CANCEL.</string>
+    <string name="actual_profile_photo">Actual profile photo :</string>
+    <string name="new_profile_photo_selected">New profile photo selected :</string>
+    <string name="error_select_new_profile_photo">You have forgot to select a new profile photo.</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -24,6 +24,11 @@
             app:useSimpleSummaryProvider="true" />
 
         <Preference
+            app:fragment="com.epfl.drawyourpath.preferences.ModifyProfilePhotoFragment"
+            app:key="modify_profilePhoto"
+            app:title="Modify Profile Photo"/>
+
+        <Preference
             app:fragment="com.epfl.drawyourpath.preferences.ModifyPasswordFragment"
             app:key="modify_password"
             app:title="Modify password" />


### PR DESCRIPTION
This PR contains a fragment inside the preferences to modify the user profile photo. This fragment contains 
- a cancel button to not modify the actual photo
- a preview of the actual photo that will be updated if a new photo is selected.
- a text description to explain the fragment 
- a text that indicate if the photo preview is the actual profile photo or the new photo selected
- a text to display an error message if the user click on validate without selecting a new profile photo
- a validate button to store the new profile photo to the database
- a select photo
 button to open the photo picker 
<img width="257" alt="Capture d’écran 2023-04-12 à 23 40 54" src="https://user-images.githubusercontent.com/79543688/231592186-022e8294-ff6b-49f5-b62d-b591b8a79290.png">

Thank you for your review 
Don't hesitate if you have any question.
Closes #102 

Remark : For the test, It is not possible to test the photo picker.