### PR TITLE
Changed the placeholder drawable in the history fragment to display a small map that shows the path of the user

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,6 +61,8 @@ dependencies {
     implementation 'androidx.preference:preference-ktx:1.2.0'
     implementation 'com.google.android.gms:play-services-maps:18.1.0'
 
+    implementation 'com.github.bumptech.glide:glide:4.15.1'
+
     testImplementation 'junit:junit:4.13.2'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/app/src/main/java/com/epfl/Utils/drawyourpath/Utils.kt
+++ b/app/src/main/java/com/epfl/Utils/drawyourpath/Utils.kt
@@ -1,0 +1,21 @@
+package com.epfl.Utils.drawyourpath
+
+import com.google.android.gms.maps.model.LatLng
+
+/**
+ * A class containing various utility functions.
+ */
+object Utils {
+    /**
+     * A function that generates a static map URL with the user's run data
+     */
+    fun getStaticMapUrl(runCoordinates: List<LatLng>, apiKey: String): String {
+        var path = "path=color:0x0000ff|weight:5"
+        for (coordinate in runCoordinates) {
+            path += "|${coordinate.latitude},${coordinate.longitude}"
+        }
+
+        val url = "https://maps.googleapis.com/maps/api/staticmap?size=80x80&maptype=roadmap&$path&key=$apiKey"
+        return url
+    }
+}

--- a/app/src/main/java/com/epfl/drawyourpath/path/RunsAdapter.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/path/RunsAdapter.kt
@@ -29,6 +29,9 @@ class RunsAdapter(private val runs: List<Run>) : RecyclerView.Adapter<RunsAdapte
 
         val runCoordinates:List<LatLng> = run.getPath().getPoints() // Get the coordinates for this specific run
         val apiKey = "AIzaSyDtCKpslh3NHncCP6chypN5CAVXbPkxPLQ"; // Replace with your Google Maps API key
+        /*NOTE Cristian's google maps api key:AIzaSyCE8covSYZE_sOv4Z-HaoljRlNOTV8cKRk
+        as the project's google maps api key is not working replace it with the one above if you want to test the app
+        but please revert it after because there are only a limited amount of free api calls*/
         val staticMapUrl = getStaticMapUrl(runCoordinates, apiKey);
 
         // Load the image using Glide

--- a/app/src/main/java/com/epfl/drawyourpath/path/RunsAdapter.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/path/RunsAdapter.kt
@@ -28,10 +28,8 @@ class RunsAdapter(private val runs: List<Run>) : RecyclerView.Adapter<RunsAdapte
 
 
         val runCoordinates:List<LatLng> = run.getPath().getPoints() // Get the coordinates for this specific run
-        val apiKey = "AIzaSyDtCKpslh3NHncCP6chypN5CAVXbPkxPLQ"; // Replace with your Google Maps API key
-        /*NOTE Cristian's google maps api key:AIzaSyCE8covSYZE_sOv4Z-HaoljRlNOTV8cKRk
-        as the project's google maps api key is not working replace it with the one above if you want to test the app
-        but please revert it after because there are only a limited amount of free api calls*/
+        val apiKey = "AIzaSyCE8covSYZE_sOv4Z-HaoljRlNOTV8cKRk";
+
         val staticMapUrl = getStaticMapUrl(runCoordinates, apiKey);
 
         // Load the image using Glide

--- a/app/src/main/java/com/epfl/drawyourpath/path/RunsAdapter.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/path/RunsAdapter.kt
@@ -7,7 +7,10 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.epfl.Utils.drawyourpath.Utils.getStaticMapUrl
 import com.epfl.drawyourpath.R
+import com.google.android.gms.maps.model.LatLng
 
 /**
  * This class is the adapter for the RecyclerView that displays the list of runs.
@@ -22,6 +25,19 @@ class RunsAdapter(private val runs: List<Run>) : RecyclerView.Adapter<RunsAdapte
     @SuppressLint("SetTextI18n")
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val run = runs[position]
+
+
+        val runCoordinates:List<LatLng> = run.getPath().getPoints() // Get the coordinates for this specific run
+        val apiKey = "AIzaSyDtCKpslh3NHncCP6chypN5CAVXbPkxPLQ"; // Replace with your Google Maps API key
+        val staticMapUrl = getStaticMapUrl(runCoordinates, apiKey);
+
+        // Load the image using Glide
+        Glide.with(holder.itemView.context)
+            .load(staticMapUrl)
+            .placeholder(R.drawable.map_loading_placeholder) // Set a placeholder image while loading
+            .into(holder.mapImageView)
+
+
 
         // Set the data to the view items in the layout
         //holder.mapImageView.setImageResource(run.mapImage)

--- a/app/src/main/res/drawable/map_loading_placeholder.xml
+++ b/app/src/main/res/drawable/map_loading_placeholder.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="#3DDC84"/>
+        </shape>
+    </item>
+    <item>
+        <rotate
+            android:fromDegrees="0"
+            android:toDegrees="360"
+            android:pivotX="50%"
+            android:pivotY="50%">
+            <shape android:shape="ring" android:innerRadiusRatio="3" android:thicknessRatio="20" android:useLevel="false">
+                <gradient
+                    android:type="sweep"
+                    android:useLevel="false"
+                    android:startColor="#FF0000"
+                    android:endColor="#0000FF"
+                    android:angle="0"/>
+            </shape>
+        </rotate>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/map_loading_placeholder.xml
+++ b/app/src/main/res/drawable/map_loading_placeholder.xml
@@ -2,7 +2,7 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="#3DDC84"/>
+            <solid android:color="@android:color/transparent"/>
         </shape>
     </item>
     <item>
@@ -12,12 +12,7 @@
             android:pivotX="50%"
             android:pivotY="50%">
             <shape android:shape="ring" android:innerRadiusRatio="3" android:thicknessRatio="20" android:useLevel="false">
-                <gradient
-                    android:type="sweep"
-                    android:useLevel="false"
-                    android:startColor="#FF0000"
-                    android:endColor="#0000FF"
-                    android:angle="0"/>
+                <solid android:color="#808080"/>
             </shape>
         </rotate>
     </item>


### PR DESCRIPTION
Description:
This pull request introduces a new feature that replaces the placeholder image in the past run items with a small map thumbnail, displaying the user's past run route. The changes include:

-A new function getStaticMapUrl which generates a static map URL using Google Static Maps API. The function takes the user's run route coordinates as input and returns a URL that can be used to fetch the map image.
-Modification of the existing RecyclerView ViewHolder to use Glide for loading the map image from the generated static map URL. Glide simplifies image loading, caching, and provides a loading icon while the image is being fetched.
-Updated the placeholder drawable with a circular progress bar to provide better visual feedback while the map image is loading.
With these changes, users will now be able to view a small map thumbnail of their past run routes, providing better context and an enhanced user experience.

![image](https://user-images.githubusercontent.com/100244309/233408421-5a830e29-0fc3-447f-9de4-9e8b11cbf1aa.png)

PS: for now I can't get access to the static API for google maps with the project API key. If you want to test functionality replace the API key in the runsAdapter class with the one provided in the comments.

Closes #91 
