### PR TITLE
113 run history cache

### DIFF
--- a/app/src/androidTest/java/com/epfl/drawyourpath/userProfile/cache/UserModelCachedTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/userProfile/cache/UserModelCachedTest.kt
@@ -149,7 +149,7 @@ class UserModelCachedTest {
 
     @Test
     fun setNewProgressModifyProgress() {
-        user.updateGoalProgress(run).get(timeout, TimeUnit.SECONDS)
+        user.addNewRun(run).get(timeout, TimeUnit.SECONDS)
         val distance = run.getDistance() / 1000.0
         val time = run.getDuration() / 60.0
         assertEqualUser(
@@ -168,7 +168,7 @@ class UserModelCachedTest {
     @Test
     fun setNewProgressWhenNoInternetDoesNotModifyProgress() {
         user.setDatabase(MockNonWorkingDatabase())
-        user.updateGoalProgress(run).exceptionally { }.get(timeout, TimeUnit.SECONDS)
+        user.addNewRun(run).exceptionally { }.get(timeout, TimeUnit.SECONDS)
         assertEqualUser(testUserModel, user.getUser().getOrAwaitValue())
         assertEquals(dailyGoal, user.getTodayDailyGoal().getOrAwaitValue())
     }

--- a/app/src/androidTest/java/com/epfl/drawyourpath/userProfile/cache/UserModelCachedTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/userProfile/cache/UserModelCachedTest.kt
@@ -1,6 +1,7 @@
 package com.epfl.drawyourpath.userProfile.cache
 
 import android.graphics.Bitmap
+import androidx.arch.core.executor.testing.CountingTaskExecutorRule
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
@@ -22,12 +23,16 @@ import java.time.LocalDate
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import kotlin.math.exp
 
 @RunWith(JUnit4::class)
 class UserModelCachedTest {
 
     @get:Rule
     var instantExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    var counting = CountingTaskExecutorRule()
 
     private val mockDataBase = MockDataBase()
 
@@ -57,9 +62,18 @@ class UserModelCachedTest {
         DailyGoal(testUserModel.getCurrentDistanceGoal(), testUserModel.getCurrentActivityTime(), testUserModel.getCurrentNumberOfPathsGoal())
 
     private val run =
-        Run(Path(listOf(LatLng(46.518493105924385, 6.561726074747257), LatLng(46.50615811055845, 6.620565690839656))), 0, 1286)
+        Run(
+            Path(listOf(LatLng(46.518493105924385, 6.561726074747257), LatLng(46.50615811055845, 6.620565690839656))),
+            mockDataBase.runTestStartTime + 10,
+            mockDataBase.runTestStartTime + 10 + 1286
+        )
 
     private val timeout: Long = 5
+
+    private fun waitUntilAllThreadAreDone() {
+        counting.drainTasks(timeout.toInt(), TimeUnit.SECONDS)
+        Thread.sleep(10)
+    }
 
     @Test
     fun getCorrectUserFromGetter() {
@@ -75,23 +89,30 @@ class UserModelCachedTest {
     fun createNewUserIsInCache() {
         // create a new user
         user.createNewUser(newUser).get(timeout, TimeUnit.SECONDS)
+        waitUntilAllThreadAreDone()
         // check if new user is correct
         assertEqualUser(newUser, user.getUser().getOrAwaitValue())
+        assertEqualRun(newUser.getRunsHistory(), user.getRunHistory().getOrAwaitValue())
         // set to another user to evict new user from livedata
         user.setCurrentUser(testUserModel.getUserId()).get(timeout, TimeUnit.SECONDS)
+        waitUntilAllThreadAreDone()
         // check that it is the correct user
         assertEqualUser(testUserModel, user.getUser().getOrAwaitValue())
+        assertEqualRun(testUserModel.getRunsHistory(), user.getRunHistory().getOrAwaitValue())
         // set non working database
         user.setDatabase(MockNonWorkingDatabase())
         // set current user to new user fom cache
         user.setCurrentUser(newUser.getUserId()).exceptionally { }.get(timeout, TimeUnit.SECONDS)
+        waitUntilAllThreadAreDone()
         // check the user in the cache
         assertEqualUser(newUser, user.getUser().getOrAwaitValue())
+        assertEqualRun(newUser.getRunsHistory(), user.getRunHistory().getOrAwaitValue())
     }
 
     @Test
     fun setUsernameModifyUsername() {
         user.updateUsername(newUser.getUsername()).get(timeout, TimeUnit.SECONDS)
+        waitUntilAllThreadAreDone()
         assertEqualUser(testUserModel, user.getUser().getOrAwaitValue(), newUsername = newUser.getUsername())
     }
 
@@ -99,12 +120,14 @@ class UserModelCachedTest {
     fun setUsernameWhenNoInternetDoesNotModifyUsername() {
         user.setDatabase(MockNonWorkingDatabase())
         user.updateUsername(newUser.getUsername()).exceptionally { }.get(timeout, TimeUnit.SECONDS)
+        waitUntilAllThreadAreDone()
         assertEqualUser(testUserModel, user.getUser().getOrAwaitValue())
     }
 
     @Test
     fun setDistanceGoalModifyDistanceGoal() {
         user.updateDistanceGoal(newUser.getCurrentDistanceGoal()).get(timeout, TimeUnit.SECONDS)
+        waitUntilAllThreadAreDone()
         assertEqualUser(testUserModel, user.getUser().getOrAwaitValue(), newDistanceGoal = newUser.getCurrentDistanceGoal())
         assertEquals(dailyGoal.copy(distanceInKilometerGoal = newUser.getCurrentDistanceGoal()), user.getTodayDailyGoal().getOrAwaitValue())
     }
@@ -113,6 +136,7 @@ class UserModelCachedTest {
     fun setDistanceGoalWhenNoInternetDoesNotModifyDistanceGoal() {
         user.setDatabase(MockNonWorkingDatabase())
         user.updateDistanceGoal(newUser.getCurrentDistanceGoal()).exceptionally { }.get(timeout, TimeUnit.SECONDS)
+        waitUntilAllThreadAreDone()
         assertEqualUser(testUserModel, user.getUser().getOrAwaitValue())
         assertEquals(dailyGoal, user.getTodayDailyGoal().getOrAwaitValue())
     }
@@ -120,6 +144,7 @@ class UserModelCachedTest {
     @Test
     fun setActivityTimeGoalModifyActivityTimeGoal() {
         user.updateActivityTimeGoal(newUser.getCurrentActivityTime()).get(timeout, TimeUnit.SECONDS)
+        waitUntilAllThreadAreDone()
         assertEqualUser(testUserModel, user.getUser().getOrAwaitValue(), newTimeGoal = newUser.getCurrentActivityTime())
         assertEquals(dailyGoal.copy(activityTimeInMinutesGoal = newUser.getCurrentActivityTime()), user.getTodayDailyGoal().getOrAwaitValue())
     }
@@ -128,6 +153,7 @@ class UserModelCachedTest {
     fun setActivityTimeGoalWhenNoInternetDoesNotModifyActivityTimeGoal() {
         user.setDatabase(MockNonWorkingDatabase())
         user.updateActivityTimeGoal(newUser.getCurrentActivityTime()).exceptionally { }.get(timeout, TimeUnit.SECONDS)
+        waitUntilAllThreadAreDone()
         assertEqualUser(testUserModel, user.getUser().getOrAwaitValue())
         assertEquals(dailyGoal, user.getTodayDailyGoal().getOrAwaitValue())
     }
@@ -135,6 +161,7 @@ class UserModelCachedTest {
     @Test
     fun setNumberOfPathsGoalModifyNumberOfPathsGoal() {
         user.updateNumberOfPathsGoal(newUser.getCurrentNumberOfPathsGoal()).get(timeout, TimeUnit.SECONDS)
+        waitUntilAllThreadAreDone()
         assertEqualUser(testUserModel, user.getUser().getOrAwaitValue(), newPathGoal = newUser.getCurrentNumberOfPathsGoal())
         assertEquals(dailyGoal.copy(nbOfPathsGoal = newUser.getCurrentNumberOfPathsGoal()), user.getTodayDailyGoal().getOrAwaitValue())
     }
@@ -143,13 +170,15 @@ class UserModelCachedTest {
     fun setNumberOfPathsGoalWhenNoInternetDoesNotModifyNumberOfPathsGoal() {
         user.setDatabase(MockNonWorkingDatabase())
         user.updateNumberOfPathsGoal(newUser.getCurrentNumberOfPathsGoal()).exceptionally { }.get(timeout, TimeUnit.SECONDS)
+        waitUntilAllThreadAreDone()
         assertEqualUser(testUserModel, user.getUser().getOrAwaitValue())
         assertEquals(dailyGoal, user.getTodayDailyGoal().getOrAwaitValue())
     }
 
     @Test
-    fun setNewProgressModifyProgress() {
+    fun addNewRunAddRunAndModifyProgress() {
         user.addNewRun(run).get(timeout, TimeUnit.SECONDS)
+        waitUntilAllThreadAreDone()
         val distance = run.getDistance() / 1000.0
         val time = run.getDuration() / 60.0
         assertEqualUser(
@@ -163,19 +192,23 @@ class UserModelCachedTest {
             dailyGoal.copy(distanceInKilometerProgress = distance, activityTimeInMinutesProgress = time, nbOfPathsProgress = 1),
             user.getTodayDailyGoal().getOrAwaitValue(),
         )
+        assertEqualRun(testUserModel.getRunsHistory().toMutableList().also { it.add(0, run) }, user.getRunHistory().getOrAwaitValue())
     }
 
     @Test
-    fun setNewProgressWhenNoInternetDoesNotModifyProgress() {
+    fun addNewRunWhenNoInternetDoesNotAddRunAndModifyProgress() {
         user.setDatabase(MockNonWorkingDatabase())
         user.addNewRun(run).exceptionally { }.get(timeout, TimeUnit.SECONDS)
+        waitUntilAllThreadAreDone()
         assertEqualUser(testUserModel, user.getUser().getOrAwaitValue())
         assertEquals(dailyGoal, user.getTodayDailyGoal().getOrAwaitValue())
+        assertEqualRun(testUserModel.getRunsHistory(), user.getRunHistory().getOrAwaitValue())
     }
 
     @Test
     fun setProfilePhotoModifyProfilePhoto() {
         user.updateProfilePhoto(newPicture).get(timeout, TimeUnit.SECONDS)
+        waitUntilAllThreadAreDone()
         assertNotNull(user.getUser().getOrAwaitValue().getProfilePhotoAsBitmap())
     }
 
@@ -183,6 +216,7 @@ class UserModelCachedTest {
     fun setProfilePhotoWhenNoInternetDoesNotModifyProfilePhoto() {
         user.setDatabase(MockNonWorkingDatabase())
         user.updateProfilePhoto(newPicture).exceptionally { }.get(timeout, TimeUnit.SECONDS)
+        waitUntilAllThreadAreDone()
         assertNull(user.getUser().getOrAwaitValue().getProfilePhotoAsBitmap())
     }
 
@@ -190,7 +224,9 @@ class UserModelCachedTest {
     fun setup() {
         user.setDatabase(mockDataBase)
         user.clearCache().get(timeout, TimeUnit.SECONDS)
+        waitUntilAllThreadAreDone()
         user.setCurrentUser(testUserModel.getUserId()).get(timeout, TimeUnit.SECONDS)
+        waitUntilAllThreadAreDone()
     }
 
     private fun assertEqualUser(
@@ -217,6 +253,21 @@ class UserModelCachedTest {
         assertEquals(expected.getTotalActivityTime() + addTimeProgress, actual.goalAndAchievements.totalActivityTime, 0.001)
         assertEquals(expected.getTotalNbOfPaths() + addPathProgress, actual.goalAndAchievements.totalNbOfPaths)
         assertEquals(expected.getProfilePhoto(), actual.getProfilePhotoAsBitmap())
+    }
+
+    private fun assertEqualRun(expected: List<Run>, actual: List<Run>) {
+        expected.forEachIndexed { index, run ->
+            assertEquals(run.getStartTime(), actual[index].getStartTime())
+            assertEquals(run.getEndTime(), actual[index].getEndTime())
+            assertEqualPath(run.getPath(), actual[index].getPath())
+        }
+    }
+
+    private fun assertEqualPath(expected: Path, actual: Path) {
+        expected.getPoints().forEachIndexed { index, latLng ->
+            assertEquals(latLng.latitude, actual.getPoints()[index].latitude, 0.00001)
+            assertEquals(latLng.longitude, actual.getPoints()[index].longitude, 0.00001)
+        }
     }
 
     /**

--- a/app/src/main/java/com/epfl/drawyourpath/path/cache/PointsEntity.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/path/cache/PointsEntity.kt
@@ -3,14 +3,11 @@ package com.epfl.drawyourpath.path.cache
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
-import com.epfl.drawyourpath.userProfile.cache.UserEntity
 
 @Entity(
     tableName = "Points",
     primaryKeys = ["user_id", "run_id", "index"],
-    foreignKeys = [ForeignKey(
-        entity = UserEntity::class, parentColumns = ["id"], childColumns = ["user_id"], onDelete = ForeignKey.CASCADE
-    ), ForeignKey(entity = RunEntity::class, parentColumns = ["start_time"], childColumns = ["run_id"], onDelete = ForeignKey.CASCADE)],
+    foreignKeys = [ForeignKey(entity = RunEntity::class, parentColumns = ["user_id", "start_time"], childColumns = ["user_id", "run_id"], onDelete = ForeignKey.CASCADE)],
 )
 data class PointsEntity(
     @ColumnInfo("user_id")

--- a/app/src/main/java/com/epfl/drawyourpath/path/cache/PointsEntity.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/path/cache/PointsEntity.kt
@@ -1,0 +1,29 @@
+package com.epfl.drawyourpath.path.cache
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import com.epfl.drawyourpath.userProfile.cache.UserEntity
+
+@Entity(
+    tableName = "Points",
+    primaryKeys = ["user_id", "run_id", "index"],
+    foreignKeys = [ForeignKey(
+        entity = UserEntity::class, parentColumns = ["id"], childColumns = ["user_id"], onDelete = ForeignKey.CASCADE
+    ), ForeignKey(entity = RunEntity::class, parentColumns = ["start_time"], childColumns = ["run_id"], onDelete = ForeignKey.CASCADE)],
+)
+data class PointsEntity(
+    @ColumnInfo("user_id")
+    val userId: String,
+
+    @ColumnInfo("run_id")
+    val runId: Long,
+
+    val index: Int,
+
+    @ColumnInfo("lat")
+    val latitude: Double,
+
+    @ColumnInfo("lon")
+    val longitude: Double
+)

--- a/app/src/main/java/com/epfl/drawyourpath/path/cache/RunDao.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/path/cache/RunDao.kt
@@ -15,33 +15,6 @@ interface RunDao {
     fun getAllRunAndPoints(userId: String): LiveData<Map<RunEntity, List<PointsEntity>>>
 
     /**
-     * insert the run with its path inside the cache
-     * @param run the run
-     * @param points the list of points
-     */
-    @Transaction
-    fun insert(run: RunEntity, points: List<PointsEntity>) {
-        insertRun(run)
-        insertAllPoints(points)
-    }
-
-    /**
-     * should not be used: use [insert] instead
-     * insert the run inside the cache
-     * @param run the run
-     */
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertRun(run: RunEntity)
-
-    /**
-     * should not be used: use [insert] instead
-     * insert the points inside the cache
-     * @param points the points
-     */
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertAllPoints(points: List<PointsEntity>)
-
-    /**
      * delete the run from the room database
      * @param run the user to delete
      */

--- a/app/src/main/java/com/epfl/drawyourpath/path/cache/RunDao.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/path/cache/RunDao.kt
@@ -11,7 +11,7 @@ interface RunDao {
      * @param userId the user id
      * @return [LiveData] of [RunEntity] and [PointsEntity]
      */
-    @Query("SELECT * FROM Run JOIN Points ON Run.user_id = Points.user_id WHERE Run.user_id = :userId")
+    @Query("SELECT * FROM Run JOIN Points ON Run.user_id = Points.user_id AND Run.start_time = Points.run_id WHERE Run.user_id = :userId ORDER BY Run.start_time DESC")
     fun getAllRunAndPoints(userId: String): LiveData<Map<RunEntity, List<PointsEntity>>>
 
     /**

--- a/app/src/main/java/com/epfl/drawyourpath/path/cache/RunDao.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/path/cache/RunDao.kt
@@ -1,0 +1,57 @@
+package com.epfl.drawyourpath.path.cache
+
+import androidx.lifecycle.LiveData
+import androidx.room.*
+
+@Dao
+interface RunDao {
+
+    /**
+     * return a map of runs and its points
+     * @param userId the user id
+     * @return [LiveData] of [RunEntity] and [PointsEntity]
+     */
+    @Query("SELECT * FROM Run JOIN Points ON Run.user_id = Points.user_id WHERE Run.user_id = :userId")
+    fun getAllRunAndPoints(userId: String): LiveData<Map<RunEntity, List<PointsEntity>>>
+
+    /**
+     * insert the run with its path inside the cache
+     * @param run the run
+     * @param points the list of points
+     */
+    @Transaction
+    fun insert(run: RunEntity, points: List<PointsEntity>) {
+        insertRun(run)
+        insertAllPoints(points)
+    }
+
+    /**
+     * should not be used: use [insert] instead
+     * insert the run inside the cache
+     * @param run the run
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insertRun(run: RunEntity)
+
+    /**
+     * should not be used: use [insert] instead
+     * insert the points inside the cache
+     * @param points the points
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insertAllPoints(points: List<PointsEntity>)
+
+    /**
+     * delete the run from the room database
+     * @param run the user to delete
+     */
+    @Delete
+    fun delete(run: RunEntity)
+
+    /**
+     * delete all the runs
+     */
+    @Query("DELETE FROM Run")
+    fun clear()
+
+}

--- a/app/src/main/java/com/epfl/drawyourpath/path/cache/RunDao.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/path/cache/RunDao.kt
@@ -12,7 +12,7 @@ interface RunDao {
      * @return [LiveData] of [RunEntity] and [PointsEntity]
      */
     @Query("SELECT * FROM Run JOIN Points ON Run.user_id = Points.user_id AND Run.start_time = Points.run_id WHERE Run.user_id = :userId ORDER BY Run.start_time DESC")
-    fun getAllRunAndPoints(userId: String): LiveData<Map<RunEntity, List<PointsEntity>>>
+    fun getAllRunsAndPoints(userId: String): LiveData<Map<RunEntity, List<PointsEntity>>>
 
     /**
      * delete the run from the room database

--- a/app/src/main/java/com/epfl/drawyourpath/path/cache/RunEntity.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/path/cache/RunEntity.kt
@@ -1,0 +1,22 @@
+package com.epfl.drawyourpath.path.cache
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import com.epfl.drawyourpath.userProfile.cache.UserEntity
+
+@Entity(
+    tableName = "Run",
+    primaryKeys = ["user_id", "start_time"],
+    foreignKeys = [ForeignKey(entity = UserEntity::class, parentColumns = ["id"], childColumns = ["user_id"], onDelete = ForeignKey.CASCADE)],
+)
+data class RunEntity(
+    @ColumnInfo("user_id")
+    val userId: String,
+
+    @ColumnInfo("start_time")
+    val startTime: Long,
+
+    @ColumnInfo("end_time")
+    val endTime: Long
+)

--- a/app/src/main/java/com/epfl/drawyourpath/path/cache/RunEntity.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/path/cache/RunEntity.kt
@@ -3,7 +3,10 @@ package com.epfl.drawyourpath.path.cache
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
+import com.epfl.drawyourpath.path.Path
+import com.epfl.drawyourpath.path.Run
 import com.epfl.drawyourpath.userProfile.cache.UserEntity
+import com.google.android.gms.maps.model.LatLng
 
 @Entity(
     tableName = "Run",
@@ -11,12 +14,37 @@ import com.epfl.drawyourpath.userProfile.cache.UserEntity
     foreignKeys = [ForeignKey(entity = UserEntity::class, parentColumns = ["id"], childColumns = ["user_id"], onDelete = ForeignKey.CASCADE)],
 )
 data class RunEntity(
-    @ColumnInfo("user_id")
-    val userId: String,
+    @ColumnInfo("user_id") val userId: String,
 
-    @ColumnInfo("start_time")
-    val startTime: Long,
+    @ColumnInfo("start_time") val startTime: Long,
 
-    @ColumnInfo("end_time")
-    val endTime: Long
-)
+    @ColumnInfo("end_time") val endTime: Long
+) {
+    companion object {
+        /**
+         * transform a list of run into entities used in the cache
+         * @param userId the user id
+         * @param runs the list of runs to transform
+         * @return a list of pair of entities
+         */
+        fun fromRunsToEntities(userId: String, runs: List<Run>): List<Pair<RunEntity, List<PointsEntity>>> {
+            return runs.map { run ->
+                Pair(RunEntity(userId, run.getStartTime(), run.getEndTime()), run.getPath().getPoints().mapIndexed { index, point ->
+                    PointsEntity(
+                        userId, run.getStartTime(), index, point.latitude, point.longitude
+                    )
+                })
+            }
+        }
+
+        /**
+         * transform an entity into a run
+         * @param runEntity the run to transform
+         * @param pointsEntity the points of the path related to the run
+         * @return the run
+         */
+        fun fromEntityToRun(runEntity: RunEntity, pointsEntity: List<PointsEntity>): Run {
+            return Run(Path(pointsEntity.map { LatLng(it.latitude, it.longitude) }), runEntity.startTime, runEntity.endTime)
+        }
+    }
+}

--- a/app/src/main/java/com/epfl/drawyourpath/userProfile/cache/UserDao.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/userProfile/cache/UserDao.kt
@@ -2,6 +2,8 @@ package com.epfl.drawyourpath.userProfile.cache
 
 import androidx.lifecycle.LiveData
 import androidx.room.*
+import com.epfl.drawyourpath.path.cache.PointsEntity
+import com.epfl.drawyourpath.path.cache.RunEntity
 import com.epfl.drawyourpath.userProfile.dailygoal.DailyGoalEntity
 
 @Dao
@@ -16,9 +18,11 @@ interface UserDao {
     fun getUserById(id: String): LiveData<UserEntity?>
 
     @Transaction
-    fun insertAll(user: UserEntity, dailyGoals: List<DailyGoalEntity>) {
+    fun insertAll(user: UserEntity, dailyGoals: List<DailyGoalEntity>, run: List<RunEntity>, points: List<PointsEntity>) {
         insertUser(user)
         insertAllDailyGoal(dailyGoals)
+        insertAllRun(run)
+        insertAllPoints(points)
     }
 
     /**
@@ -41,6 +45,20 @@ interface UserDao {
      */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertAllDailyGoal(dailyGoal: List<DailyGoalEntity>)
+
+    /**
+     * insert the run inside the cache
+     * @param run the run
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insertAllRun(run: List<RunEntity>)
+
+    /**6
+     * insert the points inside the cache
+     * @param points the points
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insertAllPoints(points: List<PointsEntity>)
 
     /**
      * update the user with new data

--- a/app/src/main/java/com/epfl/drawyourpath/userProfile/cache/UserDao.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/userProfile/cache/UserDao.kt
@@ -21,7 +21,7 @@ interface UserDao {
     fun insertAll(user: UserEntity, dailyGoals: List<DailyGoalEntity>, run: List<RunEntity>, points: List<PointsEntity>) {
         insertUser(user)
         insertAllDailyGoal(dailyGoals)
-        insertAllRun(run)
+        insertAllRuns(run)
         insertAllPoints(points)
     }
 
@@ -47,11 +47,11 @@ interface UserDao {
     fun insertAllDailyGoal(dailyGoal: List<DailyGoalEntity>)
 
     /**
-     * insert the run inside the cache
-     * @param run the run
+     * insert the runs inside the cache
+     * @param runs the run
      */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertAllRun(run: List<RunEntity>)
+    fun insertAllRuns(runs: List<RunEntity>)
 
     /**6
      * insert the points inside the cache

--- a/app/src/main/java/com/epfl/drawyourpath/userProfile/cache/UserDatabase.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/userProfile/cache/UserDatabase.kt
@@ -2,14 +2,19 @@ package com.epfl.drawyourpath.userProfile.cache
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import com.epfl.drawyourpath.path.cache.PointsEntity
+import com.epfl.drawyourpath.path.cache.RunDao
+import com.epfl.drawyourpath.path.cache.RunEntity
 import com.epfl.drawyourpath.userProfile.dailygoal.DailyGoalDao
 import com.epfl.drawyourpath.userProfile.dailygoal.DailyGoalEntity
 
-@Database(entities = [UserEntity::class, DailyGoalEntity::class], version = 3)
+@Database(entities = [UserEntity::class, DailyGoalEntity::class, RunEntity::class, PointsEntity::class], version = 4)
 abstract class UserDatabase : RoomDatabase() {
     abstract fun userDao(): UserDao
 
     abstract fun dailyGoalDao(): DailyGoalDao
+
+    abstract fun runDao(): RunDao
 
     companion object {
         const val NAME = "UserDatabase"

--- a/app/src/main/java/com/epfl/drawyourpath/userProfile/cache/UserModelCached.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/userProfile/cache/UserModelCached.kt
@@ -67,7 +67,7 @@ class UserModelCached(application: Application) : AndroidViewModel(application) 
     }
 
     // runs
-    private val runHistory: LiveData<List<Run>> = _currentUserID.switchMap { runCache.getAllRunAndPoints(it) }.map { runAndPoints ->
+    private val runHistory: LiveData<List<Run>> = _currentUserID.switchMap { runCache.getAllRunsAndPoints(it) }.map { runAndPoints ->
         runAndPoints.map { RunEntity.fromEntityToRun(it.key, it.value) }
     }
 


### PR DESCRIPTION
This PR adds the run history inside the cache

For now, adding a run in the cache will not work unless there is an internet connection (the getter works even without internet connection)

Its usage is as follow:

first we need to initialize the userModel
`private val user: UserModelCached by activityViewModels()`

the getter:
`user.getRunHistory().observe(viewLifecycleOwner) {...}`

the setter:
`user.addNewRun(run)`

closes #113 
