### PR TITLE
136-fix-formatter

### DIFF
--- a/.github/workflows/autoformat.yaml
+++ b/.github/workflows/autoformat.yaml
@@ -3,9 +3,9 @@ run-name: Code Format by ${{ github.actor }}
 on:
   push:
     branches:
-      - main
+      - !main
 jobs:
-  Explore-GitHub-Actions:
+  Auto-Format:
     runs-on: ubuntu-latest
     
     permissions:

--- a/.github/workflows/autoformat.yaml
+++ b/.github/workflows/autoformat.yaml
@@ -2,8 +2,8 @@ name: Code Auto Format
 run-name: Code Format by ${{ github.actor }}
 on:
   push:
-    branches:
-      - !main
+    branches-ignore:
+      - main
 jobs:
   Auto-Format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Changes the way the formatter runs:

The formatter now runs on each branch that is not main after a commit.

closes #136 