### PR TITLE
adapt the drawing tests with the new speed distance calculated for a run

### DIFF
--- a/app/src/androidTest/java/com/epfl/drawyourpath/pathDrawing/PathDrawingCurrentPerformanceFragmentTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/pathDrawing/PathDrawingCurrentPerformanceFragmentTest.kt
@@ -23,8 +23,8 @@ class PathDrawingCurrentPerformanceFragmentTest {
     private val mockPath = Path(listOf(LatLng(0.0, 0.0), LatLng(0.0, 1.0)))
     val date = LocalDate.of(2000, 1, 1).atTime(LocalTime.of(12, 0, 5)).toEpochSecond(ZoneOffset.UTC)
     private val mockRun = Run(path = mockPath, startTime = date, endTime = date + 75)
-    val expectedDistance = "111.19"
-    val expectedSpeed = "1482.6"
+    val expectedDistance = "111.32"
+    val expectedSpeed = "1484.26"
     val expectedTime = "00:01:15"
 
     @get:Rule

--- a/app/src/androidTest/java/com/epfl/drawyourpath/pathDrawing/PathDrawingDetailPerformanceFragmentTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/pathDrawing/PathDrawingDetailPerformanceFragmentTest.kt
@@ -23,8 +23,8 @@ class PathDrawingDetailPerformanceFragmentTest {
     private val mockPath = Path(listOf(LatLng(0.0, 0.0), LatLng(0.0, 1.0)))
     val date = LocalDate.of(2000, 1, 1).atTime(LocalTime.of(12, 0, 5)).toEpochSecond(ZoneOffset.UTC)
     private val mockRun = Run(path = mockPath, startTime = date, endTime = date + 75)
-    val expectedDistance = "111.19"
-    val expectedSpeed = "1482.6"
+    val expectedDistance = "111.32"
+    val expectedSpeed = "1484.26"
     val expectedTime = "00:01:15"
     val expectedStartTime = "12:00:05"
     val expectedEndTime = "12:01:20"

--- a/app/src/androidTest/java/com/epfl/drawyourpath/pathDrawing/PathDrawingEndFragmentTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/pathDrawing/PathDrawingEndFragmentTest.kt
@@ -27,8 +27,8 @@ class PathDrawingEndFragmentTest {
     private val mockPath = Path(listOf(LatLng(0.0, 0.0), LatLng(0.0, 1.0)))
     val date = LocalDate.of(2000, 1, 1).atTime(LocalTime.of(12, 0, 5)).toEpochSecond(ZoneOffset.UTC)
     private val mockRun = Run(path = mockPath, startTime = date, endTime = date + 75)
-    val expectedDistance = "111.19"
-    val expectedSpeed = "1482.6"
+    val expectedDistance = "111.32"
+    val expectedSpeed = "1484.26"
     val expectedTime = "00:01:15"
     val expectedStartTime = "12:00:05"
     val expectedEndTime = "12:01:20"

--- a/app/src/androidTest/java/com/epfl/drawyourpath/pathDrawing/PathDrawingMainFragmentTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/pathDrawing/PathDrawingMainFragmentTest.kt
@@ -23,8 +23,8 @@ class PathDrawingMainFragmentTest {
     private val mockPath = Path(listOf(LatLng(0.0, 0.0), LatLng(0.0, 1.0)))
     val date = LocalDate.of(2000, 1, 1).atTime(LocalTime.of(12, 0, 5)).toEpochSecond(ZoneOffset.UTC)
     private val mockRun = Run(path = mockPath, startTime = date, endTime = date + 75)
-    val expectedDistance = "111.19"
-    val expectedSpeed = "1482.6"
+    val expectedDistance = "111.32"
+    val expectedSpeed = "1484.26"
     val expectedTime = "00:01:15"
     val expectedStartTime = "12:00:05"
     val expectedEndTime = "12:01:20"


### PR DESCRIPTION
This PR fixes the drawing tests with the new calculation of the speed and distance during a run. 
close #148 