### PR TITLE
206 add db function for tournaments

### DIFF
--- a/app/src/androidTest/java/com/epfl/drawyourpath/database/FirebaseDatabaseUtilsTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/database/FirebaseDatabaseUtilsTest.kt
@@ -402,6 +402,7 @@ class FirebaseDatabaseUtilsTest {
     @Test
     fun transformPostReturnsExpectedData() {
         val post = TournamentPost(
+            postId = "post1",
             userId = "user1",
             run = Run(
                 Path(listOf(listOf(LatLng(0.1, 1.0), LatLng(1.1, 0.2)))),
@@ -411,13 +412,13 @@ class FirebaseDatabaseUtilsTest {
                 "Lion",
                 0.8,
             ),
-            votes = 2,
             date = LocalDateTime.now().minusDays(2),
-            usersVotes = mutableMapOf("user1" to 1, "user2" to 1),
+            usersVotes = mutableMapOf("user1" to -1, "user2" to -1),
         )
         val postSnapshot = mockTournamentPost(post)
         val transformedPost = FirebaseDatabaseUtils.transformPost(postSnapshot)
-        assertThat(transformedPost!!.userId, `is`(post.userId))
+        assertThat(transformedPost!!.postId, `is`(post.postId))
+        assertThat(transformedPost.userId, `is`(post.userId))
         // Just to know if the run is the same one
         assertThat(transformedPost.run.getCalories(), `is`(post.run.getCalories()))
         assertThat(transformedPost.getVotes(), `is`(post.getVotes()))
@@ -434,6 +435,7 @@ class FirebaseDatabaseUtilsTest {
     fun transformPostListReturnsExpectedData() {
         val posts = listOf(
             TournamentPost(
+                postId = "post1",
                 userId = "user1",
                 run = Run(
                     Path(listOf(listOf(LatLng(0.1, 1.0), LatLng(1.1, 0.2)))),
@@ -443,19 +445,18 @@ class FirebaseDatabaseUtilsTest {
                     "Lion",
                     0.8,
                 ),
-                votes = 2,
                 date = LocalDateTime.now().minusDays(2),
                 usersVotes = mutableMapOf("user1" to 1, "user2" to 1),
             ),
             TournamentPost(
-                "user2",
+                postId = "post2",
+                userId = "user2",
                 run = Run(
                     Path(listOf(listOf(LatLng(0.1, 1.0), LatLng(1.1, 0.2)), listOf(LatLng(9.9, 10.11)))),
                     30,
                     20,
                     50,
                 ),
-                votes = 0,
                 date = LocalDateTime.now().minusDays(3),
                 usersVotes = mutableMapOf("user1" to -1, "user2" to 1),
             ),
@@ -580,6 +581,7 @@ class FirebaseDatabaseUtilsTest {
     fun mapToTournamentReturnsExpectedValue() {
         val posts = listOf(
             TournamentPost(
+                postId = "post1",
                 userId = "user1",
                 run = Run(
                     Path(listOf(listOf(LatLng(0.1, 1.0), LatLng(1.1, 0.2)))),
@@ -589,11 +591,11 @@ class FirebaseDatabaseUtilsTest {
                     "Lion",
                     0.8,
                 ),
-                votes = 2,
                 date = LocalDateTime.now().minusDays(2),
                 usersVotes = mutableMapOf("user1" to 1, "user2" to 1),
             ),
             TournamentPost(
+                "post2",
                 "user2",
                 run = Run(
                     Path(listOf(listOf(LatLng(0.1, 1.0), LatLng(1.1, 0.2)), listOf(LatLng(9.9, 10.11)))),
@@ -601,7 +603,6 @@ class FirebaseDatabaseUtilsTest {
                     20,
                     50,
                 ),
-                votes = 0,
                 date = LocalDateTime.now().minusDays(3),
                 usersVotes = mutableMapOf("user1" to -1, "user2" to 1),
             ),

--- a/app/src/androidTest/java/com/epfl/drawyourpath/database/FirebaseDatabaseUtilsTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/database/FirebaseDatabaseUtilsTest.kt
@@ -643,6 +643,63 @@ class FirebaseDatabaseUtilsTest {
     }
 
     @Test
+    fun mapToTournamentInfoReturnsExpectedValue() {
+        val posts = listOf(
+            TournamentPost(
+                postId = "post1",
+                userId = "user1",
+                run = Run(
+                    Path(listOf(listOf(LatLng(0.1, 1.0), LatLng(1.1, 0.2)))),
+                    10,
+                    10,
+                    20,
+                    "Lion",
+                    0.8,
+                ),
+                date = LocalDateTime.now().minusDays(2),
+                usersVotes = mutableMapOf("user1" to 1, "user2" to 1),
+            ),
+            TournamentPost(
+                "post2",
+                "user2",
+                run = Run(
+                    Path(listOf(listOf(LatLng(0.1, 1.0), LatLng(1.1, 0.2)), listOf(LatLng(9.9, 10.11)))),
+                    30,
+                    20,
+                    50,
+                ),
+                date = LocalDateTime.now().minusDays(3),
+                usersVotes = mutableMapOf("user1" to -1, "user2" to 1),
+            ),
+        )
+
+        val tournament = Tournament(
+            id = "testId",
+            name = "testName",
+            description = "testDescription",
+            creatorId = "testCreatorId",
+            startDate = LocalDateTime.now(),
+            endDate = LocalDateTime.now().plusWeeks(1),
+            participants = listOf("user1", "user2"),
+            posts = posts,
+            visibility = Tournament.Visibility.PUBLIC,
+        )
+
+        val tournamentInfoDataSnapshot = mockTournamentInfo(tournament)
+        val reformedTournamentInfo = FirebaseDatabaseUtils.mapToTournamentInfo(tournamentInfoDataSnapshot)
+
+        assertThat(reformedTournamentInfo!!.id, `is`(tournament.id))
+        assertThat(reformedTournamentInfo.name, `is`(tournament.name))
+        assertThat(reformedTournamentInfo.description, `is`(tournament.description))
+        assertThat(reformedTournamentInfo.creatorId, `is`(tournament.creatorId))
+        assertThat(reformedTournamentInfo.startDate, `is`(tournament.startDate))
+        assertThat(reformedTournamentInfo.endDate, `is`(tournament.endDate))
+        assertThat(reformedTournamentInfo.participants.size, `is`(0))
+        assertThat(reformedTournamentInfo.posts.size, `is`(0))
+        assertThat(reformedTournamentInfo.visibility, `is`(tournament.visibility))
+    }
+
+    @Test
     fun mapToTournamentReturnsNullWithNullValues() {
         // With only null values
         assertEquals(FirebaseDatabaseUtils.mapToTournament(null), null)

--- a/app/src/androidTest/java/com/epfl/drawyourpath/database/FirebaseDatabaseUtilsTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/database/FirebaseDatabaseUtilsTest.kt
@@ -91,9 +91,9 @@ class FirebaseDatabaseUtilsTest {
         val snapshot = mock(DataSnapshot::class.java)
 
         val lat = mockNumberSnapshot(point.latitude)
-        `when`(snapshot.child("latitude")).thenReturn(lat)
+        `when`(snapshot.child(FirebaseKeys.POINT_LATITUDE)).thenReturn(lat)
         val long = mockNumberSnapshot(point.longitude)
-        `when`(snapshot.child("longitude")).thenReturn(long)
+        `when`(snapshot.child(FirebaseKeys.POINT_LONGITUDE)).thenReturn(long)
 
         return snapshot
     }
@@ -118,25 +118,25 @@ class FirebaseDatabaseUtilsTest {
             mockSection(it)
         }
 
-        `when`(path.child("points")).thenReturn(pathPoints)
+        `when`(path.child(FirebaseKeys.PATH_POINTS)).thenReturn(pathPoints)
         `when`(pathPoints.children).thenReturn(sectionsSnap)
 
-        `when`(snapshot.child("path")).thenReturn(path)
+        `when`(snapshot.child(FirebaseKeys.RUN_PATH)).thenReturn(path)
 
         val startTime = mockNumberSnapshot(run.getStartTime())
-        `when`(snapshot.child("startTime")).thenReturn(startTime)
+        `when`(snapshot.child(FirebaseKeys.RUN_START_TIME)).thenReturn(startTime)
 
         val duration = mockNumberSnapshot(run.getDuration())
-        `when`(snapshot.child("duration")).thenReturn(duration)
+        `when`(snapshot.child(FirebaseKeys.RUN_DURATION)).thenReturn(duration)
 
         val endTime = mockNumberSnapshot(run.getEndTime())
-        `when`(snapshot.child("endTime")).thenReturn(endTime)
+        `when`(snapshot.child(FirebaseKeys.RUN_END_TIME)).thenReturn(endTime)
 
         val predictedShape = mockSnapshot(run.predictedShape)
-        `when`(snapshot.child("predictedShape")).thenReturn(predictedShape)
+        `when`(snapshot.child(FirebaseKeys.RUN_SHAPE)).thenReturn(predictedShape)
 
         val similarityScore = mockNumberSnapshot(run.similarityScore)
-        `when`(snapshot.child("similarityScore")).thenReturn(similarityScore)
+        `when`(snapshot.child(FirebaseKeys.RUN_SCORE)).thenReturn(similarityScore)
 
         return snapshot
     }
@@ -166,15 +166,15 @@ class FirebaseDatabaseUtilsTest {
         val snapshot = mock(DataSnapshot::class.java)
 
         val postId = mockSnapshot(post.postId)
-        `when`(snapshot.child("postId")).thenReturn(postId)
+        `when`(snapshot.child(FirebaseKeys.POST_ID)).thenReturn(postId)
         val userId = mockSnapshot(post.userId)
-        `when`(snapshot.child("userId")).thenReturn(userId)
+        `when`(snapshot.child(FirebaseKeys.POST_USER_ID)).thenReturn(userId)
         val run = mockRun(post.run)
-        `when`(snapshot.child("run")).thenReturn(run)
+        `when`(snapshot.child(FirebaseKeys.POST_RUN)).thenReturn(run)
         val date = mockLocalDateTime(post.date)
-        `when`(snapshot.child("date")).thenReturn(date)
+        `when`(snapshot.child(FirebaseKeys.POST_DATE)).thenReturn(date)
         val usersVotes = mockSnapshot(post.getUsersVotes())
-        `when`(snapshot.child("usersVotes")).thenReturn(usersVotes)
+        `when`(snapshot.child(FirebaseKeys.POST_USERS_VOTES)).thenReturn(usersVotes)
 
         return snapshot
     }
@@ -704,9 +704,9 @@ class FirebaseDatabaseUtilsTest {
         // With only null values
         assertEquals(FirebaseDatabaseUtils.mapToTournament(null), null)
         // With existing visibility but other values null, to test other path
-        val mockVisibility = mockSnapshot("PUBLIC")
+        val mockVisibility = mockSnapshot(Tournament.Visibility.PUBLIC.toString())
         val nonNullVisibilitySnapshot = mock(DataSnapshot::class.java)
-        `when`(nonNullVisibilitySnapshot.child("visibility"))
+        `when`(nonNullVisibilitySnapshot.child(FirebaseKeys.TOURNAMENT_VISIBILITY))
             .thenReturn(mockVisibility)
         assertEquals(FirebaseDatabaseUtils.mapToTournament(nonNullVisibilitySnapshot), null)
     }
@@ -716,7 +716,7 @@ class FirebaseDatabaseUtilsTest {
         // Create a mock that returns a "wrong" visibility for the tournament
         val mockVisibility = mockSnapshot("SomeVisibility")
         val nonNullVisibilitySnapshot = mock(DataSnapshot::class.java)
-        `when`(nonNullVisibilitySnapshot.child("visibility"))
+        `when`(nonNullVisibilitySnapshot.child(FirebaseKeys.TOURNAMENT_VISIBILITY))
             .thenReturn(mockVisibility)
         assertEquals(FirebaseDatabaseUtils.mapToTournament(nonNullVisibilitySnapshot), null)
     }

--- a/app/src/androidTest/java/com/epfl/drawyourpath/database/FirebaseDatabaseUtilsTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/database/FirebaseDatabaseUtilsTest.kt
@@ -165,12 +165,12 @@ class FirebaseDatabaseUtilsTest {
     private fun mockTournamentPost(post: TournamentPost): DataSnapshot {
         val snapshot = mock(DataSnapshot::class.java)
 
+        val postId = mockSnapshot(post.postId)
+        `when`(snapshot.child("postId")).thenReturn(postId)
         val userId = mockSnapshot(post.userId)
         `when`(snapshot.child("userId")).thenReturn(userId)
         val run = mockRun(post.run)
         `when`(snapshot.child("run")).thenReturn(run)
-        val votes = mockNumberSnapshot(post.getVotes())
-        `when`(snapshot.child("votes")).thenReturn(votes)
         val date = mockLocalDateTime(post.date)
         `when`(snapshot.child("date")).thenReturn(date)
         val usersVotes = mockSnapshot(post.getUsersVotes())
@@ -190,26 +190,38 @@ class FirebaseDatabaseUtilsTest {
         return snapshot
     }
 
-    private fun mockTournament(tournament: Tournament): DataSnapshot {
+    private fun mockTournamentInfo(tournament: Tournament): DataSnapshot {
         val snapshot = mock(DataSnapshot::class.java)
 
         val id = mockSnapshot(tournament.id)
-        `when`(snapshot.child("id")).thenReturn(id)
+        `when`(snapshot.child(FirebaseKeys.TOURNAMENT_ID)).thenReturn(id)
 
         val name = mockSnapshot(tournament.name)
-        `when`(snapshot.child("name")).thenReturn(name)
+        `when`(snapshot.child(FirebaseKeys.TOURNAMENT_NAME)).thenReturn(name)
 
         val description = mockSnapshot(tournament.description)
-        `when`(snapshot.child("description")).thenReturn(description)
+        `when`(snapshot.child(FirebaseKeys.TOURNAMENT_DESCRIPTION)).thenReturn(description)
 
         val creatorId = mockSnapshot(tournament.creatorId)
-        `when`(snapshot.child("creatorId")).thenReturn(creatorId)
+        `when`(snapshot.child(FirebaseKeys.TOURNAMENT_CREATOR_ID)).thenReturn(creatorId)
 
         val startDate = mockLocalDateTime(tournament.startDate)
-        `when`(snapshot.child("startDate")).thenReturn(startDate)
+        `when`(snapshot.child(FirebaseKeys.TOURNAMENT_START_DATE)).thenReturn(startDate)
 
         val endDate = mockLocalDateTime(tournament.endDate)
-        `when`(snapshot.child("endDate")).thenReturn(endDate)
+        `when`(snapshot.child(FirebaseKeys.TOURNAMENT_END_DATE)).thenReturn(endDate)
+
+        val visibility = mockSnapshot(tournament.visibility.name)
+        `when`(snapshot.child(FirebaseKeys.TOURNAMENT_VISIBILITY)).thenReturn(visibility)
+
+        return snapshot
+    }
+
+    private fun mockTournament(tournament: Tournament): DataSnapshot {
+        val snapshot = mock(DataSnapshot::class.java)
+
+        val tournamentInfo = mockTournamentInfo(tournament)
+        `when`(snapshot.child(FirebaseKeys.TOURNAMENT_INFO)).thenReturn(tournamentInfo)
 
         val participants = mock(DataSnapshot::class.java)
         val participantsSubNodes = tournament.participants.map {
@@ -218,14 +230,11 @@ class FirebaseDatabaseUtilsTest {
             `when`(participant.key).thenReturn(it)
             participant
         }
-        `when`(snapshot.child("participants")).thenReturn(participants)
+        `when`(snapshot.child(FirebaseKeys.TOURNAMENT_PARTICIPANTS_IDS)).thenReturn(participants)
         `when`(participants.children).thenReturn(participantsSubNodes)
 
         val posts = mockTournamentPostList(tournament.posts)
-        `when`(snapshot.child("posts")).thenReturn(posts)
-
-        val visibility = mockSnapshot(tournament.visibility.name)
-        `when`(snapshot.child("visibility")).thenReturn(visibility)
+        `when`(snapshot.child(FirebaseKeys.TOURNAMENT_POSTS)).thenReturn(posts)
 
         return snapshot
     }

--- a/app/src/androidTest/java/com/epfl/drawyourpath/database/MockDatabaseTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/database/MockDatabaseTest.kt
@@ -17,6 +17,7 @@ import com.epfl.drawyourpath.community.Tournament
 import com.epfl.drawyourpath.path.Path
 import com.epfl.drawyourpath.path.Run
 import com.google.android.gms.maps.model.LatLng
+import org.junit.Assert
 import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test
@@ -921,6 +922,69 @@ class MockDatabaseTest {
         val obtainTournament = database.getTournament(expectedTournamentId)
         waitUntilAllThreadAreDone()
         assertEquals(expectedTournament, obtainTournament.value)
+    }
+
+    /**
+     * Test if trying to retrieve the info an non-existing tournament from the database throws.
+     */
+    @Test
+    fun getTournamentInfoThatDoesNotExistThrows() {
+        val database = MockDatabase()
+        val tournamentId = "NotAnID"
+        assertThrows(Throwable::class.java) {
+            database.getTournamentInfo(tournamentId)
+        }
+    }
+
+    /**
+     * Test if retrieving the info of an existing tournament from the database returns the tournament.
+     */
+    @Test
+    fun getTournamentInfoThatExistsReturnsTheTournament() {
+        val database = MockDatabase()
+        val expectedTournament = database.mockTournament.value!!.copy(participants = emptyList(), posts = emptyList())
+        val expectedTournamentid = expectedTournament.id
+        val expectedTournamentId = expectedTournamentid
+        val obtainTournament = database.getTournamentInfo(expectedTournamentId)
+        waitUntilAllThreadAreDone()
+        assertEquals(expectedTournament, obtainTournament.value)
+    }
+
+    /**
+     * Test if trying to retrieve the posts an non-existing tournament from the database throws.
+     */
+    @Test
+    fun getTournamentPostsThatDoesNotExistThrows() {
+        val database = MockDatabase()
+        val tournamentId = "NotAnID"
+        assertThrows(Throwable::class.java) {
+            database.getTournamentPosts(tournamentId)
+        }
+    }
+
+    /**
+     * Test if retrieving the posts of an existing tournament from the database returns the tournament.
+     */
+    @Test
+    fun getTournamentPostsThatExistsReturnsTheTournament() {
+        val database = MockDatabase()
+        val expectedPost = database.mockTournament.value!!.posts
+        val expectedTournamentId = database.mockTournament.value!!.id
+        val obtainPost = database.getTournamentPosts(expectedTournamentId)
+        waitUntilAllThreadAreDone()
+        assertEquals(expectedPost, obtainPost.value)
+    }
+
+    /**
+     * Check that getTournamentsId return the correct list of tournaments Id
+     */
+    @Test
+    fun getTournamentIdCorrectly() {
+        val database = MockDatabase()
+        val expectedList = database.MOCK_TOURNAMENTS_ID.value!!.toList()
+        val obtainList = database.getAllTournamentsId()
+        waitUntilAllThreadAreDone()
+        assertEquals(expectedList, obtainList.value)
     }
 
     /**

--- a/app/src/androidTest/java/com/epfl/drawyourpath/database/MockDatabaseTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/database/MockDatabaseTest.kt
@@ -17,7 +17,6 @@ import com.epfl.drawyourpath.community.Tournament
 import com.epfl.drawyourpath.path.Path
 import com.epfl.drawyourpath.path.Run
 import com.google.android.gms.maps.model.LatLng
-import org.junit.Assert
 import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/androidTest/java/com/epfl/drawyourpath/database/MockDatabaseTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/database/MockDatabaseTest.kt
@@ -704,9 +704,9 @@ class MockDatabaseTest {
     @Test
     fun getTournamentUIDReturnsANewID() {
         val database = MockDatabase()
-        var currUID = database.getTournamentUID()
+        var currUID = database.getTournamentUniqueId()
         for (i: Int in 0..9) {
-            val newID = database.getTournamentUID()
+            val newID = database.getTournamentUniqueId()
             assertEquals(currUID.toInt() + 1, newID.toInt())
             currUID = newID
         }
@@ -719,7 +719,7 @@ class MockDatabaseTest {
     fun addTournamentAddsNewTournamentToDatabase() {
         val database = MockDatabase()
         val newTournament = Tournament(
-            id = database.getTournamentUID(),
+            id = database.getTournamentUniqueId(),
             name = "testName",
             description = "testDesc",
             creatorId = "testCreator",

--- a/app/src/androidTest/java/com/epfl/drawyourpath/database/MockDatabaseTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/database/MockDatabaseTest.kt
@@ -50,7 +50,7 @@ class MockDatabaseTest {
      */
     private fun waitUntilAllThreadAreDone() {
         executorRule.drainTasks(2, TimeUnit.SECONDS)
-        Thread.sleep(50)
+        Thread.sleep(100)
     }
 
     /**
@@ -730,9 +730,10 @@ class MockDatabaseTest {
         assertTrue(!database.tournaments.containsKey(newTournament.id))
         // add the tournament
         database.addTournament(newTournament).get()
+        waitUntilAllThreadAreDone()
         // check that the tournament is stored with its id as key
         assertTrue(database.tournaments.containsKey(newTournament.id))
-        assertEquals(newTournament, database.tournaments[newTournament.id])
+        assertEquals(newTournament, database.tournaments[newTournament.id]!!.value)
     }
 
     /**
@@ -750,11 +751,12 @@ class MockDatabaseTest {
             endDate = LocalDateTime.now().plusDays(3L),
         )
         // check that the tournament is not the same beforehand
-        assertNotEquals(newTournament, database.tournaments[database.mockTournament.value!!.id])
+        assertNotEquals(newTournament, database.tournaments[database.mockTournament.value!!.id]!!.value)
         // add  the tournament
         database.addTournament(newTournament).get()
+        waitUntilAllThreadAreDone()
         // check that the tournament has been replaced
-        assertEquals(newTournament, database.tournaments[database.mockTournament.value!!.id])
+        assertEquals(newTournament, database.tournaments[database.mockTournament.value!!.id]!!.value)
     }
 
     /**
@@ -837,6 +839,7 @@ class MockDatabaseTest {
         assertTrue(!database.users[userId]!!.tournaments!!.contains(tournamentId))
         // add user to tournament
         database.addUserToTournament(userId, tournamentId).get()
+        waitUntilAllThreadAreDone()
         // check that user is in tournament's participants
         assertTrue(database.tournaments[tournamentId]!!.value!!.participants.contains(userId))
         // check that tournament is in user's tournaments list
@@ -876,6 +879,7 @@ class MockDatabaseTest {
         assertTrue(database.users[userId]!!.tournaments!!.contains(tournamentId))
         // remove user from tournament
         database.removeUserFromTournament(userId, tournamentId)
+        waitUntilAllThreadAreDone()
         // check that user is not in tournament's participants
         assertTrue(!database.tournaments[tournamentId]!!.value!!.participants.contains(userId))
         // check that tournament is not in user's tournaments list
@@ -911,10 +915,12 @@ class MockDatabaseTest {
     @Test
     fun getTournamentThatExistsReturnsTheTournament() {
         val database = MockDatabase()
-        val expectedTournament = database.mockTournament
-        val expectedTournamentid = expectedTournament.value!!.id
+        val expectedTournament = database.mockTournament.value!!.copy()
+        val expectedTournamentid = expectedTournament.id
         val expectedTournamentId = expectedTournamentid
-        assertEquals(expectedTournament, database.getTournament(expectedTournamentId).value)
+        val obtainTournament = database.getTournament(expectedTournamentId)
+        waitUntilAllThreadAreDone()
+        assertEquals(expectedTournament, obtainTournament.value)
     }
 
     /**

--- a/app/src/androidTest/java/com/epfl/drawyourpath/database/MockDatabaseTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/database/MockDatabaseTest.kt
@@ -79,7 +79,7 @@ class MockDatabaseTest {
     @Test
     fun isTournamentInDatabasePresent() {
         val database = MockDatabase()
-        val test = database.isTournamentInDatabase(database.mockTournament.id).get()
+        val test = database.isTournamentInDatabase(database.mockTournament.value!!.id).get()
         assertEquals(true, test)
     }
 
@@ -742,7 +742,7 @@ class MockDatabaseTest {
     fun addNewTournamentWithExistingIdReplacesTournament() {
         val database = MockDatabase()
         val newTournament = Tournament(
-            id = database.mockTournament.id,
+            id = database.mockTournament.value!!.id,
             name = "testName",
             description = "testDesc",
             creatorId = "testCreator",
@@ -750,11 +750,11 @@ class MockDatabaseTest {
             endDate = LocalDateTime.now().plusDays(3L),
         )
         // check that the tournament is not the same beforehand
-        assertNotEquals(newTournament, database.tournaments[database.mockTournament.id])
+        assertNotEquals(newTournament, database.tournaments[database.mockTournament.value!!.id])
         // add  the tournament
         database.addTournament(newTournament).get()
         // check that the tournament has been replaced
-        assertEquals(newTournament, database.tournaments[database.mockTournament.id])
+        assertEquals(newTournament, database.tournaments[database.mockTournament.value!!.id])
     }
 
     /**
@@ -764,8 +764,8 @@ class MockDatabaseTest {
     @Test
     fun removeTournamentsRemovesTournamentFromGeneralAndUsersTournamentsFiles() {
         val database = MockDatabase()
-        val tournamentToRemove = database.mockTournament.id
-        val tournamentsToRemoveParticipants = database.mockTournament.participants
+        val tournamentToRemove = database.mockTournament.value!!.id
+        val tournamentsToRemoveParticipants = database.mockTournament.value!!.participants
         // check that the tournament is in general list of tournaments
         assertTrue(database.tournaments.containsKey(tournamentToRemove))
         assertEquals(database.mockTournament, database.tournaments[tournamentToRemove])
@@ -802,7 +802,7 @@ class MockDatabaseTest {
     @Test
     fun addingNonExistingUserToTournamentThrows() {
         val database = MockDatabase()
-        val tournamentId = database.mockTournament.id
+        val tournamentId = database.mockTournament.value!!.id
         val userId = "NotAnID"
         assertThrows(Throwable::class.java) {
             database.addUserToTournament(userId, tournamentId).get()
@@ -829,16 +829,16 @@ class MockDatabaseTest {
     @Test
     fun addingExistingUserToExistingTournamentWorks() {
         val database = MockDatabase()
-        val tournamentId = database.MOCK_TOURNAMENTS[1].id
+        val tournamentId = database.MOCK_TOURNAMENTS[1].value!!.id
         val userId = MockDatabase.mockUser.userId!!
         // check that user is not in tournament's participants
-        assertTrue(!database.tournaments[tournamentId]!!.participants.contains(userId))
+        assertTrue(!database.tournaments[tournamentId]!!.value!!.participants.contains(userId))
         // check that tournament is not in user's tournaments list
         assertTrue(!database.users[userId]!!.tournaments!!.contains(tournamentId))
         // add user to tournament
         database.addUserToTournament(userId, tournamentId).get()
         // check that user is in tournament's participants
-        assertTrue(database.tournaments[tournamentId]!!.participants.contains(userId))
+        assertTrue(database.tournaments[tournamentId]!!.value!!.participants.contains(userId))
         // check that tournament is in user's tournaments list
         assertTrue(database.users[userId]!!.tournaments!!.contains(tournamentId))
     }
@@ -849,14 +849,14 @@ class MockDatabaseTest {
     @Test
     fun addingUserAlreadyInTournamentDoesNothing() {
         val database = MockDatabase()
-        val tournamentId = database.MOCK_TOURNAMENTS[0].id
-        val numberParticipants = database.MOCK_TOURNAMENTS[0].participants.size
+        val tournamentId = database.MOCK_TOURNAMENTS[0].value!!.id
+        val numberParticipants = database.MOCK_TOURNAMENTS[0].value!!.participants.size
         val userId = MockDatabase.mockUser.userId!!
         val numberTournamentsOfUser = MockDatabase.mockUser.tournaments!!.size
         // try to add user
         database.addUserToTournament(userId, tournamentId).get()
         // does not add a participant
-        assertEquals(numberParticipants, database.tournaments[tournamentId]!!.participants.size)
+        assertEquals(numberParticipants, database.tournaments[tournamentId]!!.value!!.participants.size)
         // does not add a tournament to the user
         assertEquals(numberTournamentsOfUser, database.users[userId]!!.tournaments!!.size)
     }
@@ -868,16 +868,16 @@ class MockDatabaseTest {
     @Test
     fun removingExistingUserFromExistingTournamentWorks() {
         val database = MockDatabase()
-        val tournamentId = database.mockTournament.id
+        val tournamentId = database.mockTournament.value!!.id
         val userId = MockDatabase.mockUser.userId!!
         // check that user is in tournament's participants
-        assertTrue(database.tournaments[tournamentId]!!.participants.contains(userId))
+        assertTrue(database.tournaments[tournamentId]!!.value!!.participants.contains(userId))
         // check that tournament is in user's tournaments list
         assertTrue(database.users[userId]!!.tournaments!!.contains(tournamentId))
         // remove user from tournament
         database.removeUserFromTournament(userId, tournamentId)
         // check that user is not in tournament's participants
-        assertTrue(!database.tournaments[tournamentId]!!.participants.contains(userId))
+        assertTrue(!database.tournaments[tournamentId]!!.value!!.participants.contains(userId))
         // check that tournament is not in user's tournaments list
         assertTrue(!database.users[userId]!!.tournaments!!.contains(tournamentId))
     }
@@ -901,7 +901,7 @@ class MockDatabaseTest {
         val database = MockDatabase()
         val tournamentId = "NotAnID"
         assertThrows(Throwable::class.java) {
-            database.getTournament(tournamentId).get()
+            database.getTournament(tournamentId)
         }
     }
 
@@ -912,8 +912,9 @@ class MockDatabaseTest {
     fun getTournamentThatExistsReturnsTheTournament() {
         val database = MockDatabase()
         val expectedTournament = database.mockTournament
-        val expectedTournamentId = expectedTournament.id
-        assertEquals(expectedTournament, database.getTournament(expectedTournamentId).get())
+        val expectedTournamentid = expectedTournament.value!!.id
+        val expectedTournamentId = expectedTournamentid
+        assertEquals(expectedTournament, database.getTournament(expectedTournamentId).value)
     }
 
     /**

--- a/app/src/androidTest/java/com/epfl/drawyourpath/database/MockNonWorkingDatabaseTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/database/MockNonWorkingDatabaseTest.kt
@@ -6,6 +6,7 @@ import com.epfl.drawyourpath.challenge.trophy.Trophy
 import com.epfl.drawyourpath.path.Path
 import com.epfl.drawyourpath.path.Run
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Test
 import java.time.LocalDate
 import java.util.concurrent.CompletableFuture
@@ -37,23 +38,27 @@ class MockNonWorkingDatabaseTest {
         mock.addTrophy("", Trophy("", "", "", LocalDate.of(2000, 2, 20), 1)).assertError(Unit)
         mock.addMilestone("", MilestoneEnum.HUNDRED_KILOMETERS, LocalDate.of(2000, 2, 20)).assertError(Unit)
         mock.createChatConversation("", emptyList(), "", "").assertError("")
-        mock.getChatPreview("")
+        assertThrows(Exception::class.java) { mock.getChatPreview("") }
         mock.setChatTitle("", "").assertError(Unit)
         mock.getChatMemberList("").assertError(mockChatMembers)
         mock.addChatMember("", "").assertError(Unit)
         mock.removeChatMember("", "").assertError(Unit)
-        mock.getChatMessages("")
-        mock.getFriendsList("")
+        assertThrows(Exception::class.java) { mock.getChatMessages("") }
+        assertThrows(Exception::class.java) { mock.getFriendsList("") }
         mock.addChatMessage("", mockChatMessages.value!!.get(0)).assertError(Unit)
         mock.removeChatMessage("", 0L).assertError(Unit)
         mock.modifyChatTextMessage("", 0L, "").assertError(Unit)
         mock.setUserData("", UserData()).assertError(Unit)
         mock.addRunToHistory("", Run(Path(), 1, 9, 10)).assertError(Unit)
         mock.removeRunFromHistory("", Run(Path(), 1, 9, 10)).assertError(Unit)
-        mock.addTournament(mockTournament).assertError(Unit)
+        mock.addTournament(mockTournament.value!!).assertError(Unit)
         mock.removeTournament("").assertError(Unit)
         mock.addUserToTournament("", "").assertError(Unit)
         mock.removeUserFromTournament("", "").assertError(Unit)
+        assertThrows(Exception::class.java) { mock.getAllTournamentsId() }
+        assertThrows(Exception::class.java) { mock.getTournament("") }
+        assertThrows(Exception::class.java) { mock.getTournamentInfo("") }
+        assertThrows(Exception::class.java) { mock.getTournamentPosts("") }
     }
 
     /**

--- a/app/src/androidTest/java/com/epfl/drawyourpath/database/MockNonWorkingDatabaseTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/database/MockNonWorkingDatabaseTest.kt
@@ -3,6 +3,7 @@ package com.epfl.drawyourpath.database
 import com.epfl.drawyourpath.challenge.dailygoal.DailyGoal
 import com.epfl.drawyourpath.challenge.milestone.MilestoneEnum
 import com.epfl.drawyourpath.challenge.trophy.Trophy
+import com.epfl.drawyourpath.community.TournamentPost
 import com.epfl.drawyourpath.path.Path
 import com.epfl.drawyourpath.path.Run
 import org.junit.Assert.assertEquals
@@ -24,6 +25,7 @@ class MockNonWorkingDatabaseTest {
 
         mock.isUserInDatabase("").assertError(true)
         mock.isTournamentInDatabase("").assertError(true)
+        mock.isPostInDatabase("", "").assertError(true)
         mock.getUsername("").assertError("")
         mock.getUserIdFromUsername("").assertError("")
         mock.isUsernameAvailable("").assertError(true)
@@ -54,15 +56,21 @@ class MockNonWorkingDatabaseTest {
         mock.removeTournament("").assertError(Unit)
         mock.addUserToTournament("", "").assertError(Unit)
         mock.removeUserFromTournament("", "").assertError(Unit)
+        mock.getTournamentPosts("").assertError(emptyList())
+        mock.getTournamentParticipantsId("").assertError(emptyList())
+        mock.getTournamentInfo("").assertError(mockTournament)
+        mock.addPostToTournament("", TournamentPost("", "", Run(Path(), 1, 9, 10))).assertError(Unit)
+        mock.voteOnPost("", "", "", 0).assertError(Unit)
     }
 
     /**
      * Test if getTournamentUID() returns null (as it doesn't return a future)
      */
     @Test
-    fun getTournamentUIDReturnsNull() {
+    fun getTournamentAndPostUIDReturnsNull() {
         val mock = MockNonWorkingDatabase()
         assertEquals(null, mock.getTournamentUID())
+        assertEquals(null, mock.getPostUID())
     }
 
     private fun <T> CompletableFuture<T>.assertError(ret: T) {

--- a/app/src/androidTest/java/com/epfl/drawyourpath/database/MockNonWorkingDatabaseTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/database/MockNonWorkingDatabaseTest.kt
@@ -72,8 +72,8 @@ class MockNonWorkingDatabaseTest {
     @Test
     fun getTournamentAndPostUIDReturnsNull() {
         val mock = MockNonWorkingDatabase()
-        assertEquals(null, mock.getTournamentUID())
-        assertEquals(null, mock.getPostUID())
+        assertEquals(null, mock.getTournamentUniqueId())
+        assertEquals(null, mock.getPostUniqueId())
     }
 
     private fun <T> CompletableFuture<T>.assertError(ret: T) {

--- a/app/src/androidTest/java/com/epfl/drawyourpath/mainpage/fragments/CommunityFragmentTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/mainpage/fragments/CommunityFragmentTest.kt
@@ -272,7 +272,7 @@ class CommunityFragmentTest {
      */
     private val postsYour = mutableListOf(
         TournamentPost("post1", "Michel", sampleRun()),
-        TournamentPost("post2","MrPrefect", sampleRun()),
+        TournamentPost("post2", "MrPrefect", sampleRun()),
         TournamentPost("post3", "Me Myself and I", sampleRun()),
         TournamentPost("post4", "Invalid Username", sampleRun()),
     )
@@ -281,7 +281,7 @@ class CommunityFragmentTest {
      * sample posts
      */
     private val postsDiscoverEarth = mutableListOf(
-        TournamentPost("post5","SpaceMan", sampleRun()),
+        TournamentPost("post5", "SpaceMan", sampleRun()),
         TournamentPost("post6", "NASA", sampleRun()),
         TournamentPost("post7", "Alien", sampleRun()),
     )

--- a/app/src/androidTest/java/com/epfl/drawyourpath/mainpage/fragments/CommunityFragmentTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/mainpage/fragments/CommunityFragmentTest.kt
@@ -41,7 +41,7 @@ class CommunityFragmentTest {
             0.9,
         )
         val userVotes = mutableMapOf("test" to 1)
-        val post = TournamentPost("testId", run, 1, usersVotes = userVotes)
+        val post = TournamentPost("0", "testId", run, LocalDateTime.now(), usersVotes = userVotes)
         assertThat(post.getUsersVotes(), `is`(userVotes))
     }
 
@@ -271,27 +271,27 @@ class CommunityFragmentTest {
      * sample posts
      */
     private val postsYour = mutableListOf(
-        TournamentPost("Michel", sampleRun(), 158),
-        TournamentPost("MrPrefect", sampleRun(), 666),
-        TournamentPost("Me Myself and I", sampleRun(), 123456),
-        TournamentPost("Invalid Username", sampleRun(), 0),
+        TournamentPost("0", "Michel", sampleRun(), LocalDateTime.now()),
+        TournamentPost("1", "MrPrefect", sampleRun(), LocalDateTime.now()),
+        TournamentPost("2", "Me Myself and I", sampleRun(), LocalDateTime.now()),
+        TournamentPost("3", "Invalid Username", sampleRun(), LocalDateTime.now()),
     )
 
     /**
      * sample posts
      */
     private val postsDiscoverEarth = mutableListOf(
-        TournamentPost("SpaceMan", sampleRun(), 35),
-        TournamentPost("NASA", sampleRun(), 124),
-        TournamentPost("Alien", sampleRun(), -3),
+        TournamentPost("0", "SpaceMan", sampleRun(), LocalDateTime.now()),
+        TournamentPost("1", "NASA", sampleRun(), LocalDateTime.now()),
+        TournamentPost("2","Alien", sampleRun(), LocalDateTime.now()),
     )
 
     /**
      * sample posts
      */
     private val postsDiscoverMoon = mutableListOf(
-        TournamentPost("Diabolos", sampleRun(), 666),
-        TournamentPost("Jaqueline", sampleRun(), 356),
+        TournamentPost("0", "Diabolos", sampleRun(), LocalDateTime.now()),
+        TournamentPost("1","Jaqueline", sampleRun(), LocalDateTime.now()),
     )
 
     /**
@@ -305,7 +305,7 @@ class CommunityFragmentTest {
         LocalDateTime.now().plusDays(4L),
         LocalDateTime.now().plusDays(3L),
         listOf(),
-        listOf(TournamentPost("xxDarkxx", sampleRun(), -13)),
+        listOf(TournamentPost("0","xxDarkxx", sampleRun(), LocalDateTime.now())),
     )
 
     /**

--- a/app/src/androidTest/java/com/epfl/drawyourpath/mainpage/fragments/CommunityFragmentTest.kt
+++ b/app/src/androidTest/java/com/epfl/drawyourpath/mainpage/fragments/CommunityFragmentTest.kt
@@ -41,7 +41,7 @@ class CommunityFragmentTest {
             0.9,
         )
         val userVotes = mutableMapOf("test" to 1)
-        val post = TournamentPost("testId", run, 1, usersVotes = userVotes)
+        val post = TournamentPost("postId", "testId", run, usersVotes = userVotes)
         assertThat(post.getUsersVotes(), `is`(userVotes))
     }
 
@@ -271,27 +271,27 @@ class CommunityFragmentTest {
      * sample posts
      */
     private val postsYour = mutableListOf(
-        TournamentPost("Michel", sampleRun(), 158),
-        TournamentPost("MrPrefect", sampleRun(), 666),
-        TournamentPost("Me Myself and I", sampleRun(), 123456),
-        TournamentPost("Invalid Username", sampleRun(), 0),
+        TournamentPost("post1", "Michel", sampleRun()),
+        TournamentPost("post2","MrPrefect", sampleRun()),
+        TournamentPost("post3", "Me Myself and I", sampleRun()),
+        TournamentPost("post4", "Invalid Username", sampleRun()),
     )
 
     /**
      * sample posts
      */
     private val postsDiscoverEarth = mutableListOf(
-        TournamentPost("SpaceMan", sampleRun(), 35),
-        TournamentPost("NASA", sampleRun(), 124),
-        TournamentPost("Alien", sampleRun(), -3),
+        TournamentPost("post5","SpaceMan", sampleRun()),
+        TournamentPost("post6", "NASA", sampleRun()),
+        TournamentPost("post7", "Alien", sampleRun()),
     )
 
     /**
      * sample posts
      */
     private val postsDiscoverMoon = mutableListOf(
-        TournamentPost("Diabolos", sampleRun(), 666),
-        TournamentPost("Jaqueline", sampleRun(), 356),
+        TournamentPost("post8", "Diabolos", sampleRun()),
+        TournamentPost("post9", "Jaqueline", sampleRun()),
     )
 
     /**
@@ -305,7 +305,7 @@ class CommunityFragmentTest {
         LocalDateTime.now().plusDays(4L),
         LocalDateTime.now().plusDays(3L),
         listOf(),
-        listOf(TournamentPost("xxDarkxx", sampleRun(), -13)),
+        listOf(TournamentPost("post10", "xxDarkxx", sampleRun())),
     )
 
     /**

--- a/app/src/main/java/com/epfl/drawyourpath/community/Tournament.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/community/Tournament.kt
@@ -17,7 +17,6 @@ data class Tournament(
     val endDate: LocalDateTime,
     // Exclude to avoid storing the participants as a list
     @get:Exclude val participants: List<String> = mutableListOf(),
-    // Could also exclude, but need a key to get the posts
     val posts: List<TournamentPost> = mutableListOf(),
     var visibility: Visibility = Visibility.PUBLIC,
     // val result: List<User>?

--- a/app/src/main/java/com/epfl/drawyourpath/community/TournamentCreationFragment.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/community/TournamentCreationFragment.kt
@@ -83,7 +83,7 @@ class TournamentCreationFragment : Fragment(R.layout.fragment_tournament_creatio
         }
 
         // get a uid for the tournament from database (client side)
-        val id = database.getTournamentUID()
+        val id = database.getTournamentUniqueId()
         if (id == null) {
             Toast.makeText(
                 activity,

--- a/app/src/main/java/com/epfl/drawyourpath/community/TournamentPost.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/community/TournamentPost.kt
@@ -1,22 +1,26 @@
 package com.epfl.drawyourpath.community
 
 import com.epfl.drawyourpath.path.Run
+import com.google.firebase.database.Exclude
 import java.time.LocalDateTime
 import kotlin.collections.HashMap
 
 data class TournamentPost(
+    val postId: String,
     val userId: String,
     val run: Run,
-    private var votes: Int = 0,
     val date: LocalDateTime = LocalDateTime.now(),
     private var usersVotes: MutableMap<String, Int> = HashMap(),
 ) : java.io.Serializable {
+
+    private var votes = usersVotes.values.sum()
 
     /**
      * get the total number of votes
      *
      * @return the total number of votes
      */
+    @Exclude
     fun getVotes(): Int {
         return votes
     }

--- a/app/src/main/java/com/epfl/drawyourpath/community/TournamentPostCreationView.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/community/TournamentPostCreationView.kt
@@ -74,6 +74,9 @@ class TournamentPostCreationView : Fragment(R.layout.fragment_tournament_post_cr
         val post = view.findViewById<Button>(R.id.post_creation_post_button)
         post.setOnClickListener {
             // TODO add the post to the database
+            // 1. get a uid from db
+            // 2. create the TournamentPost object
+            // 3. call Database.addPostToTournament()
             requireActivity().supportFragmentManager.popBackStack()
         }
     }

--- a/app/src/main/java/com/epfl/drawyourpath/database/Database.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/Database.kt
@@ -259,7 +259,7 @@ abstract class Database {
     ): CompletableFuture<Unit>
 
     /**
-     * Function used to retrieve the tournament corresponding to the ID. USe only if you need to get
+     * Function used to retrieve the tournament corresponding to the ID. Use only if you need to get
      * everything about a tournament (including posts and participants). Otherwise, you should use
      * [getTournamentInfo], [getTournamentPosts] or [getTournamentParticipantsId].
      * @param tournamentId the id of the tournaments to retrieve.

--- a/app/src/main/java/com/epfl/drawyourpath/database/Database.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/Database.kt
@@ -74,6 +74,14 @@ abstract class Database {
     abstract fun isTournamentInDatabase(tournamentId: String): CompletableFuture<Boolean>
 
     /**
+     * This function is used to know if a certain tournament is stored in the database
+     * @param tournamentId that corresponds to the tournament in which the post should be
+     * @param postId that corresponds to the post
+     * @return a future that indicates if the post is stored on the database
+     */
+    abstract fun isPostInDatabase(tournamentId: String, postId: String): CompletableFuture<Boolean>
+
+    /**
      * This function will return a future that give the username in function of the userId
      * @param userId of the user
      * @return a future that gives the username of the user
@@ -248,7 +256,7 @@ abstract class Database {
      * Function used to retrieve the tournament corresponding to the ID. USe only if you need to get
      * everything about a tournament (including posts and participants). Otherwise, you should use
      * [getTournamentInfo], [getTournamentPosts] or [getTournamentParticipantsId].
-     * @param tournamentId the id of the tournaments to retrieve
+     * @param tournamentId the id of the tournaments to retrieve.
      * @return a future that contains the tournament if successful, or an exception if an error
      * occurred with the db.
      */
@@ -258,7 +266,7 @@ abstract class Database {
 
     /**
      * Function used to retrieve all posts from the tournament corresponding to the ID.
-     * @param tournamentId the id of the tournaments to retrieve
+     * @param tournamentId the id of the tournaments to retrieve.
      * @return a future that contains the list of the posts of the tournament.
      */
     abstract fun getTournamentPosts(
@@ -267,7 +275,7 @@ abstract class Database {
 
     /**
      * Function used to retrieve the participants of a tournament.
-     * @param tournamentId the id of the tournaments from which we want the participants
+     * @param tournamentId the id of the tournaments from which we want the participants.
      * @return a future that contains the list of participants if successful.
      */
     abstract fun getTournamentParticipantsId(
@@ -277,12 +285,44 @@ abstract class Database {
     /**
      * Function used to retrieve only the info about the tournament, not the posts or the participants
      * to avoid too much downloading.
-     * @param tournamentId the id of the tournament from which we want the info
+     * @param tournamentId the id of the tournament from which we want the info.
      * @return a future that contains the tournament which has empty posts and participants ids lists.
      */
     abstract fun getTournamentInfo(
         tournamentId: String,
     ): CompletableFuture<Tournament>
+
+    /**
+     * Function used to get a unique ID for a new post. Never fails (because client side).
+     * @return a unique ID or null if the operation failed.
+     */
+    abstract fun getPostUID(): String?
+
+    /**
+     * Function used to add a post to a tournament.
+     * @param tournamentId the id of the tournament to which we want to add the post.
+     * @param post the post to add to the tournament.
+     * @return a future indicating if the operation was successful.
+     */
+    abstract fun addPostToTournament(
+        tournamentId: String,
+        post: TournamentPost,
+    ): CompletableFuture<Unit>
+
+    /**
+     * Function used to add or overwrite/change a vote on a post.
+     * @param tournamentId the tournament in which the post is.
+     * @param postId the id of the post.
+     * @param userId the id of the user who votes.
+     * @param vote the new vote value: downvote = -1, no vote = 0, upvote = 1.
+     * @return a future indicating if the operation was successful.
+     */
+    abstract fun voteOnPost(
+        userId: String,
+        tournamentId: String,
+        postId: String,
+        vote: Int,
+    ): CompletableFuture<Unit>
 
     /**
      * Function used to create a chat conversation with other users of the DrawYourPath community.

--- a/app/src/main/java/com/epfl/drawyourpath/database/Database.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/Database.kt
@@ -207,6 +207,12 @@ abstract class Database {
     ): CompletableFuture<Unit>
 
     /**
+     * Function to return the list of the tournaments Ids available in the database
+     * @return a live data that contains the list of the tournaments ids available in the database
+     */
+    abstract fun getAllTournamentsId(): LiveData<List<String>>
+
+    /**
      * Function used to get a unique ID for a new tournament. Never fails (because client side).
      * @return a unique ID or null if the operation failed.
      */
@@ -257,21 +263,21 @@ abstract class Database {
      * everything about a tournament (including posts and participants). Otherwise, you should use
      * [getTournamentInfo], [getTournamentPosts] or [getTournamentParticipantsId].
      * @param tournamentId the id of the tournaments to retrieve.
-     * @return a future that contains the tournament if successful, or an exception if an error
+     * @return a live data that contains the tournament if successful, or an exception if an error
      * occurred with the db.
      */
     abstract fun getTournament(
         tournamentId: String,
-    ): CompletableFuture<Tournament>
+    ): LiveData<Tournament>
 
     /**
      * Function used to retrieve all posts from the tournament corresponding to the ID.
      * @param tournamentId the id of the tournaments to retrieve.
-     * @return a future that contains the list of the posts of the tournament.
+     * @return a live data that contains the list of the posts of the tournament.
      */
     abstract fun getTournamentPosts(
         tournamentId: String,
-    ): CompletableFuture<List<TournamentPost>>
+    ): LiveData<List<TournamentPost>>
 
     /**
      * Function used to retrieve the participants of a tournament.
@@ -286,11 +292,11 @@ abstract class Database {
      * Function used to retrieve only the info about the tournament, not the posts or the participants
      * to avoid too much downloading.
      * @param tournamentId the id of the tournament from which we want the info.
-     * @return a future that contains the tournament which has empty posts and participants ids lists.
+     * @return a live data that contains the tournament which has empty posts and participants ids lists.
      */
     abstract fun getTournamentInfo(
         tournamentId: String,
-    ): CompletableFuture<Tournament>
+    ): LiveData<Tournament>
 
     /**
      * Function used to get a unique ID for a new post. Never fails (because client side).

--- a/app/src/main/java/com/epfl/drawyourpath/database/Database.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/Database.kt
@@ -216,7 +216,7 @@ abstract class Database {
      * Function used to get a unique ID for a new tournament. Never fails (because client side).
      * @return a unique ID or null if the operation failed.
      */
-    abstract fun getTournamentUID(): String?
+    abstract fun getTournamentUniqueId(): String?
 
     /**
      * Function used to add a new tournament to the database. The participants and posts of the
@@ -302,7 +302,7 @@ abstract class Database {
      * Function used to get a unique ID for a new post. Never fails (because client side).
      * @return a unique ID or null if the operation failed.
      */
-    abstract fun getPostUID(): String?
+    abstract fun getPostUniqueId(): String?
 
     /**
      * Function used to add a post to a tournament.

--- a/app/src/main/java/com/epfl/drawyourpath/database/Database.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/Database.kt
@@ -8,9 +8,9 @@ import com.epfl.drawyourpath.challenge.milestone.MilestoneEnum
 import com.epfl.drawyourpath.challenge.trophy.Trophy
 import com.epfl.drawyourpath.chat.Message
 import com.epfl.drawyourpath.community.Tournament
+import com.epfl.drawyourpath.community.TournamentPost
 import com.epfl.drawyourpath.path.Run
 import java.time.LocalDate
-import java.util.*
 import java.util.concurrent.CompletableFuture
 
 data class UserGoals(
@@ -181,7 +181,7 @@ abstract class Database {
 
     /**
      * This function is used to add a trophy to the user profile of the user in the database
-     * @param tropy to be stored in the database
+     * @param trophy to be stored in the database
      * @return a future to indicate if the trophy was correctly added to the user profile on the database
      */
     abstract fun addTrophy(userId: String, trophy: Trophy): CompletableFuture<Unit>
@@ -245,12 +245,42 @@ abstract class Database {
     ): CompletableFuture<Unit>
 
     /**
-     * Function used to retrieve the tournament corresponding to the ID.
+     * Function used to retrieve the tournament corresponding to the ID. USe only if you need to get
+     * everything about a tournament (including posts and participants). Otherwise, you should use
+     * [getTournamentInfo], [getTournamentPosts] or [getTournamentParticipantsId].
      * @param tournamentId the id of the tournaments to retrieve
      * @return a future that contains the tournament if successful, or an exception if an error
      * occurred with the db.
      */
     abstract fun getTournament(
+        tournamentId: String,
+    ): CompletableFuture<Tournament>
+
+    /**
+     * Function used to retrieve all posts from the tournament corresponding to the ID.
+     * @param tournamentId the id of the tournaments to retrieve
+     * @return a future that contains the list of the posts of the tournament.
+     */
+    abstract fun getTournamentPosts(
+        tournamentId: String,
+    ): CompletableFuture<List<TournamentPost>>
+
+    /**
+     * Function used to retrieve the participants of a tournament.
+     * @param tournamentId the id of the tournaments from which we want the participants
+     * @return a future that contains the list of participants if successful.
+     */
+    abstract fun getTournamentParticipantsId(
+        tournamentId: String,
+    ): CompletableFuture<List<String>>
+
+    /**
+     * Function used to retrieve only the info about the tournament, not the posts or the participants
+     * to avoid too much downloading.
+     * @param tournamentId the id of the tournament from which we want the info
+     * @return a future that contains the tournament which has empty posts and participants ids lists.
+     */
+    abstract fun getTournamentInfo(
         tournamentId: String,
     ): CompletableFuture<Tournament>
 

--- a/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabase.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabase.kt
@@ -87,6 +87,28 @@ object FirebaseKeys {
     const val TOURNAMENT_END_DATE = "endDate"
     const val TOURNAMENT_VISIBILITY = "visibility"
 
+    // Posts keys
+    const val POST_ID = "postId"
+    const val POST_USER_ID = "userId"
+    const val POST_RUN = "run"
+    const val POST_DATE = "date"
+    const val POST_USERS_VOTES = "usersVotes"
+
+    // Run keys
+    const val RUN_PATH = "path"
+    const val RUN_START_TIME = "startTime"
+    const val RUN_DURATION = "duration"
+    const val RUN_END_TIME = "endTime"
+    const val RUN_SHAPE = "predictedShape"
+    const val RUN_SCORE = "similarityScore"
+
+    // Path keys
+    const val PATH_POINTS = "points"
+
+    // Points keys
+    const val POINT_LATITUDE = "latitude"
+    const val POINT_LONGITUDE = "longitude"
+
     // Chats keys top level
     const val CHAT_TITLE = "title"
     const val CHAT_LAST_MESSAGE = "lastMessage"

--- a/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabase.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabase.kt
@@ -711,8 +711,8 @@ class FirebaseDatabase(reference: DatabaseReference = Firebase.database.referenc
         isUserInDatabase(userId).thenCombine(
             isPostInDatabase(
                 tournamentId,
-                postId
-            )
+                postId,
+            ),
         ) { userExists, postExists ->
             if (!userExists) {
                 future.completeExceptionally(Exception("The user with userId $userId doesn't exist."))
@@ -831,7 +831,7 @@ class FirebaseDatabase(reference: DatabaseReference = Firebase.database.referenc
         }
         // add the listener on the database messages
         userProfile(userId).child(FirebaseKeys.USER_CHATS).ref.addValueEventListener(
-            chatValueEventListener
+            chatValueEventListener,
         )
         return chatValues
     }
@@ -1064,9 +1064,9 @@ class FirebaseDatabase(reference: DatabaseReference = Firebase.database.referenc
         val data = mapOf(
             FirebaseKeys.CHAT_TITLE to chatPreview.title,
             "${FirebaseKeys.CHAT_LAST_MESSAGE}/${chatPreview.lastMessage!!.timestamp}/${FirebaseKeys.CHAT_MESSAGE_SENDER}" to
-                    chatPreview.lastMessage.senderId,
+                chatPreview.lastMessage.senderId,
             "${FirebaseKeys.CHAT_LAST_MESSAGE}/${chatPreview.lastMessage.timestamp}/${FirebaseKeys.CHAT_MESSAGE_CONTENT_TEXT}" to
-                    (chatPreview.lastMessage.content as MessageContent.Text?)?.text,
+                (chatPreview.lastMessage.content as MessageContent.Text?)?.text,
         ).filter { it.value != null }
 
         chatPreview(conversationId).updateChildren(data)

--- a/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabase.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabase.kt
@@ -155,7 +155,7 @@ class FirebaseDatabase(reference: DatabaseReference = Firebase.database.referenc
     /**
      * Used to get the database reference to the file containing the ids of all tournaments.
      */
-    private fun tournamentsKeysRoot(): DatabaseReference {
+    private fun tournamentsIdsRoot(): DatabaseReference {
         return database.child(FirebaseKeys.TOURNAMENTS_IDS_ROOT)
     }
 
@@ -237,7 +237,7 @@ class FirebaseDatabase(reference: DatabaseReference = Firebase.database.referenc
     override fun isTournamentInDatabase(tournamentId: String): CompletableFuture<Boolean> {
         val future = CompletableFuture<Boolean>()
 
-        tournamentsKeysRoot().child(tournamentId).get()
+        tournamentsIdsRoot().child(tournamentId).get()
             .addOnSuccessListener {
                 future.complete(it.value != null)
             }
@@ -580,7 +580,7 @@ class FirebaseDatabase(reference: DatabaseReference = Firebase.database.referenc
             }
         }
         // add the listener on the database tournaments root
-        tournamentsRoot().ref.addValueEventListener(tournamentsIdValueEventListener)
+        tournamentsIdsRoot().ref.addValueEventListener(tournamentsIdValueEventListener)
         return tournamentsIdValues
     }
 
@@ -592,7 +592,7 @@ class FirebaseDatabase(reference: DatabaseReference = Firebase.database.referenc
         val future = CompletableFuture<Unit>()
         // add the tournament to all tournaments
         val changes: MutableMap<String, Any?> = hashMapOf(
-            "${FirebaseKeys.TOURNAMENTS_ROOT}/${FirebaseKeys.TOURNAMENT_INFO}/${tournament.id}" to tournament,
+            "${FirebaseKeys.TOURNAMENTS_ROOT}/${tournament.id}/${FirebaseKeys.TOURNAMENT_INFO}" to tournament,
             "${FirebaseKeys.TOURNAMENTS_IDS_ROOT}/${tournament.id}" to true,
         )
         database.updateChildren(changes).addOnSuccessListener { future.complete(Unit) }
@@ -690,7 +690,7 @@ class FirebaseDatabase(reference: DatabaseReference = Firebase.database.referenc
             }
         }
         // add the listener on the database on the root of the tournament with tournament id
-        tournamentsKeysRoot().child(tournamentId).ref.addValueEventListener(tournamentValueEventListener)
+        tournamentsRoot().child(tournamentId).ref.addValueEventListener(tournamentValueEventListener)
         return tournamentValue
     }
 
@@ -819,6 +819,8 @@ class FirebaseDatabase(reference: DatabaseReference = Firebase.database.referenc
                 // if they exist, change/add the user vote
                 tournamentsRoot().child("$tournamentId/${FirebaseKeys.TOURNAMENT_POSTS}/$postId/userVotes/$userId")
                     .setValue(vote)
+                    .addOnSuccessListener { future.complete(Unit) }
+                    .addOnFailureListener { future.completeExceptionally(it) }
             }
         }
         return future

--- a/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabase.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabase.kt
@@ -145,10 +145,16 @@ class FirebaseDatabase(reference: DatabaseReference = Firebase.database.referenc
         return nameMappingRoot().child(username)
     }
 
+    /**
+     * Used to get the database reference of the file containing the (whole) tournaments.
+     */
     private fun tournamentsRoot(): DatabaseReference {
         return database.child(FirebaseKeys.TOURNAMENTS_ROOT)
     }
 
+    /**
+     * Used to get the database reference to the file containing the ids of all tournaments.
+     */
     private fun tournamentsKeysRoot(): DatabaseReference {
         return database.child(FirebaseKeys.TOURNAMENTS_IDS_ROOT)
     }
@@ -721,7 +727,7 @@ class FirebaseDatabase(reference: DatabaseReference = Firebase.database.referenc
             if (!tournamentExists) {
                 future.completeExceptionally(Exception("The tournament with tournamentId $tournamentId doesn't exist."))
             } else {
-                // Get tournament posts
+                // Get tournament participants
                 tournamentsRoot().child(tournamentId)
                     .child(FirebaseKeys.TOURNAMENT_PARTICIPANTS_IDS).get().addOnSuccessListener {
                         future.complete(FirebaseDatabaseUtils.getKeys(it))

--- a/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabase.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabase.kt
@@ -584,7 +584,7 @@ class FirebaseDatabase(reference: DatabaseReference = Firebase.database.referenc
         return tournamentsIdValues
     }
 
-    override fun getTournamentUID(): String? {
+    override fun getTournamentUniqueId(): String? {
         return database.child(FirebaseKeys.TOURNAMENTS_ROOT).push().key
     }
 
@@ -769,7 +769,7 @@ class FirebaseDatabase(reference: DatabaseReference = Firebase.database.referenc
         return tournamentInfoValue
     }
 
-    override fun getPostUID(): String? {
+    override fun getPostUniqueId(): String? {
         return database.child(FirebaseKeys.TOURNAMENTS_ROOT).child(FirebaseKeys.TOURNAMENT_POSTS)
             .push().key
     }

--- a/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabaseUtils.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabaseUtils.kt
@@ -88,10 +88,10 @@ object FirebaseDatabaseUtils {
      * @return the run corresponding to the data
      */
     fun transformRun(data: DataSnapshot?): Run? {
-        val sections = data?.child("path")?.child("points")?.children?.map { section ->
+        val sections = data?.child(FirebaseKeys.RUN_PATH)?.child(FirebaseKeys.PATH_POINTS)?.children?.map { section ->
             section.children.mapNotNull { point ->
-                val lat = getNumber(point.child("latitude"))?.toDouble()
-                val lon = getNumber(point.child("longitude"))?.toDouble()
+                val lat = getNumber(point.child(FirebaseKeys.POINT_LATITUDE))?.toDouble()
+                val lon = getNumber(point.child(FirebaseKeys.POINT_LONGITUDE))?.toDouble()
                 if (lat != null && lon != null) {
                     LatLng(lat, lon)
                 } else {
@@ -101,11 +101,11 @@ object FirebaseDatabaseUtils {
             }
         } ?: emptyList()
 
-        val startTime = getNumber(data?.child("startTime"))?.toLong()
-        val duration = getNumber(data?.child("duration"))?.toLong()
-        val endTime = getNumber(data?.child("endTime"))?.toLong()
-        val predictedShape = (data?.child("predictedShape")?.value ?: "None") as String
-        val similarityScore = (getNumber(data?.child("similarityScore")) ?: 0.0).toDouble()
+        val startTime = getNumber(data?.child(FirebaseKeys.RUN_START_TIME))?.toLong()
+        val duration = getNumber(data?.child(FirebaseKeys.RUN_DURATION))?.toLong()
+        val endTime = getNumber(data?.child(FirebaseKeys.RUN_END_TIME))?.toLong()
+        val predictedShape = (data?.child(FirebaseKeys.RUN_SHAPE)?.value ?: "None") as String
+        val similarityScore = (getNumber(data?.child(FirebaseKeys.RUN_SCORE)) ?: 0.0).toDouble()
         if (startTime == null) {
             Log.e(this::class.java.name, "Run start time was null.")
             return null
@@ -145,13 +145,13 @@ object FirebaseDatabaseUtils {
      * @return the post, or null if an error occurred
      */
     fun transformPost(data: DataSnapshot?): TournamentPost? {
-        val postId = data?.child("postId")?.value as String?
-        val userId = data?.child("userId")?.value as String?
-        val run = transformRun(data?.child("run"))
-        val date = transformLocalDateTime(data?.child("date"))
+        val postId = data?.child(FirebaseKeys.POST_ID)?.value as String?
+        val userId = data?.child(FirebaseKeys.POST_USER_ID)?.value as String?
+        val run = transformRun(data?.child(FirebaseKeys.POST_RUN))
+        val date = transformLocalDateTime(data?.child(FirebaseKeys.POST_DATE))
         // Unchecked cast here but should work without problem
         val usersVotes =
-            (data?.child("usersVotes")?.value ?: emptyMap<String, Int>()) as Map<String, Int>
+            (data?.child(FirebaseKeys.POST_USERS_VOTES)?.value ?: emptyMap<String, Int>()) as Map<String, Int>
 
         if (postId == null || userId == null || run == null || date == null) {
             Log.e(this::class.java.name, "TournamentPost had null values")

--- a/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabaseUtils.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabaseUtils.kt
@@ -290,17 +290,7 @@ object FirebaseDatabaseUtils {
             return null
         }
 
-        return Tournament(
-            tournamentInfo.id,
-            tournamentInfo.name,
-            tournamentInfo.description,
-            tournamentInfo.creatorId,
-            tournamentInfo.startDate,
-            tournamentInfo.endDate,
-            participants,
-            posts,
-            tournamentInfo.visibility,
-        )
+        return tournamentInfo.copy(participants = participants, posts = posts)
     }
 
     /**

--- a/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabaseUtils.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabaseUtils.kt
@@ -145,20 +145,20 @@ object FirebaseDatabaseUtils {
      * @return the post, or null if an error occurred
      */
     fun transformPost(data: DataSnapshot?): TournamentPost? {
+        val postId = data?.child("postId")?.value as String?
         val userId = data?.child("userId")?.value as String?
         val run = transformRun(data?.child("run"))
-        val votes = getNumber(data?.child("votes"))?.toInt()
         val date = transformLocalDateTime(data?.child("date"))
         // Unchecked cast here but should work without problem
         val usersVotes =
             (data?.child("usersVotes")?.value ?: emptyMap<String, Int>()) as Map<String, Int>
 
-        if (userId == null || run == null || votes == null || date == null) {
+        if (postId == null || userId == null || run == null || date == null) {
             Log.e(this::class.java.name, "TournamentPost had null values")
             return null
         }
 
-        return TournamentPost(userId, run, votes, date, usersVotes.toMutableMap())
+        return TournamentPost(postId, userId, run, date, usersVotes.toMutableMap())
     }
 
     /**

--- a/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabaseUtils.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabaseUtils.kt
@@ -281,14 +281,40 @@ object FirebaseDatabaseUtils {
      * @return the tournament, or null if an error occurred
      */
     fun mapToTournament(data: DataSnapshot?): Tournament? {
+        val tournamentInfo = mapToTournamentInfo(data?.child(FirebaseKeys.TOURNAMENT_INFO))
+        val participants = getKeys(data?.child(FirebaseKeys.TOURNAMENT_PARTICIPANTS_IDS))
+        val posts = transformPostList(data?.child(FirebaseKeys.TOURNAMENT_POSTS))
+
+        if (tournamentInfo == null) {
+            Log.e(this::class.java.name, "Tournament had null values")
+            return null
+        }
+
+        return Tournament(
+            tournamentInfo.id,
+            tournamentInfo.name,
+            tournamentInfo.description,
+            tournamentInfo.creatorId,
+            tournamentInfo.startDate,
+            tournamentInfo.endDate,
+            participants,
+            posts,
+            tournamentInfo.visibility,
+        )
+    }
+
+    /**
+     * Helper function to convert a data snapshot to a tournament
+     * @param data the data snapshot containing the tournament info
+     * @return the tournament info, or null if an error occurred
+     */
+    fun mapToTournamentInfo(data: DataSnapshot?): Tournament? {
         val id = data?.child(FirebaseKeys.TOURNAMENT_ID)?.value as String?
         val name = data?.child(FirebaseKeys.TOURNAMENT_NAME)?.value as String?
         val description = data?.child(FirebaseKeys.TOURNAMENT_DESCRIPTION)?.value as String?
         val creatorId = data?.child(FirebaseKeys.TOURNAMENT_CREATOR_ID)?.value as String?
         val startDate = transformLocalDateTime(data?.child(FirebaseKeys.TOURNAMENT_START_DATE))
         val endDate = transformLocalDateTime(data?.child(FirebaseKeys.TOURNAMENT_END_DATE))
-        val participants = getKeys(data?.child(FirebaseKeys.TOURNAMENT_PARTICIPANTS_IDS))
-        val posts = transformPostList(data?.child(FirebaseKeys.TOURNAMENT_POSTS))
         val visibilityString = data?.child(FirebaseKeys.TOURNAMENT_VISIBILITY)?.value as String?
 
         // Get the visibility back to an enum value
@@ -311,22 +337,22 @@ object FirebaseDatabaseUtils {
         }
 
         return Tournament(
-            id,
-            name,
-            description,
-            creatorId,
-            startDate,
-            endDate,
-            participants,
-            posts,
-            visibility,
+            id = id,
+            name = name,
+            description = description,
+            creatorId = creatorId,
+            startDate = startDate,
+            endDate = endDate,
+            visibility = visibility,
         )
     }
+
+
 
     /**
      * Helper function to transform a trophy object into an object to store in the database
      * The tournament id is not take into account since is used as a key for the trophy in the database.
-     * @param tropy to store in the database
+     * @param trophy to store in the database
      */
     fun transformTrophyToData(trophy: Trophy): HashMap<String, Any> {
         return hashMapOf(
@@ -373,7 +399,6 @@ object FirebaseDatabaseUtils {
     /**
      * Helper function to transform a milestone object enum with a date into an object to store in the database
      * The tournament id is not take into account since is used as a key for the trophy in the database.
-     * @param tropy to store in the database
      */
     fun transformMilestoneToData(milestone: MilestoneEnum, date: LocalDate): HashMap<String, Any> {
         return hashMapOf(

--- a/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabaseUtils.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabaseUtils.kt
@@ -351,6 +351,7 @@ object FirebaseDatabaseUtils {
      * Helper function to transform a trophy object into an object to store in the database
      * The tournament id is not take into account since is used as a key for the trophy in the database.
      * @param trophy to store in the database
+     * @return a map that can be stored in Firebase Database
      */
     fun transformTrophyToData(trophy: Trophy): HashMap<String, Any> {
         return hashMapOf(
@@ -397,6 +398,9 @@ object FirebaseDatabaseUtils {
     /**
      * Helper function to transform a milestone object enum with a date into an object to store in the database
      * The tournament id is not take into account since is used as a key for the trophy in the database.
+     * @param milestone the milestone object enum to store
+     * @param date the date to store alongside the milestone
+     * @return a map linking the milestone's name to the day of the date.
      */
     fun transformMilestoneToData(milestone: MilestoneEnum, date: LocalDate): HashMap<String, Any> {
         return hashMapOf(

--- a/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabaseUtils.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/FirebaseDatabaseUtils.kt
@@ -347,8 +347,6 @@ object FirebaseDatabaseUtils {
         )
     }
 
-
-
     /**
      * Helper function to transform a trophy object into an object to store in the database
      * The tournament id is not take into account since is used as a key for the trophy in the database.

--- a/app/src/main/java/com/epfl/drawyourpath/database/MockDatabase.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/MockDatabase.kt
@@ -254,7 +254,16 @@ class MockDatabase : Database() {
         usersVotes = hashMapOf(
             MOCK_USERS[0].userId!! to 1,
             MOCK_USERS[1].userId!! to -1,
-        )
+        ),
+    )
+
+    val MOCK_POSTS = listOf(
+        mockPost,
+        TournamentPost(
+            postId = "mockPostID2",
+            userId = MOCK_USERS[0].userId!!,
+            run = MOCK_USERS[0].runs!![0],
+        ),
     )
 
     val mockTournament = MutableLiveData(
@@ -267,12 +276,12 @@ class MockDatabase : Database() {
             endDate = LocalDateTime.now().plusDays(4L),
             participants = MOCK_USERS.map { it.userId!! },
             // The next args are useless for now
-            posts = listOf(),
+            posts = listOf(mockPost),
             visibility = Tournament.Visibility.PUBLIC,
         ),
     )
 
-    val MOCK_TOURNAMENTS_ID = MutableLiveData<List<String>>(
+    val MOCK_TOURNAMENTS_ID = MutableLiveData(
         listOf(
             "0",
             "1",
@@ -793,14 +802,15 @@ class MockDatabase : Database() {
         }
 
         val oldTournament = tournaments[tournamentId]!!.value!!
-        val posts = oldTournament.posts
-        val oldPost = posts.first { it.postId == postId }
-        val oldPostIndex = posts.indexOf(oldPost)
+        val oldPosts = oldTournament.posts
+        val oldPost = oldPosts.first { it.postId == postId }
+        val oldPostIndex = oldPosts.indexOf(oldPost)
         val newUsersVotes = oldPost.getUsersVotes().plus(userId to vote).toMutableMap()
         val newPost = oldPost.copy(usersVotes = newUsersVotes)
-        posts.toMutableList().set(oldPostIndex, newPost)
+        val newPosts = oldPosts.toMutableList()
+        newPosts.set(oldPostIndex, newPost)
 
-        tournaments[tournamentId]!!.postValue(oldTournament.copy(posts = posts))
+        tournaments[tournamentId]!!.postValue(oldTournament.copy(posts = newPosts))
 
         return CompletableFuture.completedFuture(Unit)
     }

--- a/app/src/main/java/com/epfl/drawyourpath/database/MockDatabase.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/MockDatabase.kt
@@ -245,6 +245,16 @@ class MockDatabase : Database() {
         mockUser,
     )
 
+    val mockPost = TournamentPost(
+        postId = "mockPostID",
+        userId = mockUser.userId!!,
+        run = mockUser.runs!![0],
+        usersVotes = hashMapOf(
+            MOCK_USERS[0].userId!! to 1,
+            MOCK_USERS[1].userId!! to -1,
+        )
+    )
+
     val mockTournament = Tournament(
         id = "0",
         name = "mockTournament0",
@@ -254,7 +264,7 @@ class MockDatabase : Database() {
         endDate = LocalDateTime.now().plusDays(4L),
         participants = MOCK_USERS.map { it.userId!! },
         // The next args are useless for now
-        posts = listOf(),
+        posts = listOf(mockPost),
         visibility = Tournament.Visibility.PUBLIC,
     )
 

--- a/app/src/main/java/com/epfl/drawyourpath/database/MockDatabase.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/MockDatabase.kt
@@ -370,7 +370,7 @@ class MockDatabase : Database() {
         postId: String,
     ): CompletableFuture<Boolean> {
         val postExists = tournaments.keys.contains(tournamentId) &&
-                tournaments[tournamentId]!!.posts.any { it.postId == postId }
+            tournaments[tournamentId]!!.posts.any { it.postId == postId }
         return CompletableFuture.completedFuture(postExists)
     }
 

--- a/app/src/main/java/com/epfl/drawyourpath/database/MockDatabase.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/MockDatabase.kt
@@ -320,7 +320,7 @@ class MockDatabase : Database() {
 
     )
 
-    var mockUID = 1234567
+    var mockUniqueId = 1234567
 
     var MOCK_CHAT_PREVIEWS = listOf(
         ChatPreview(
@@ -634,8 +634,8 @@ class MockDatabase : Database() {
         return MOCK_TOURNAMENTS_ID
     }
 
-    override fun getTournamentUID(): String {
-        return mockUID++.toString()
+    override fun getTournamentUniqueId(): String {
+        return mockUniqueId++.toString()
     }
 
     override fun addTournament(tournament: Tournament): CompletableFuture<Unit> {
@@ -767,8 +767,8 @@ class MockDatabase : Database() {
         return infoLiveData
     }
 
-    override fun getPostUID(): String {
-        return mockUID++.toString()
+    override fun getPostUniqueId(): String {
+        return mockUniqueId++.toString()
     }
 
     override fun addPostToTournament(

--- a/app/src/main/java/com/epfl/drawyourpath/database/MockDatabase.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/MockDatabase.kt
@@ -300,7 +300,6 @@ class MockDatabase : Database() {
                 startDate = LocalDateTime.now().plusDays(1L),
                 endDate = LocalDateTime.now().plusDays(2L),
                 participants = listOf(MOCK_USERS[0].userId!!, MOCK_USERS[1].userId!!),
-                // The next args are useless for now
                 posts = listOf(),
                 visibility = Tournament.Visibility.PUBLIC,
             ),
@@ -314,7 +313,6 @@ class MockDatabase : Database() {
                 startDate = LocalDateTime.now().plusDays(2L),
                 endDate = LocalDateTime.now().plusDays(3L),
                 participants = listOf(MOCK_USERS[1].userId!!),
-                // The next args are useless for now
                 posts = listOf(),
                 visibility = Tournament.Visibility.PUBLIC,
             ),

--- a/app/src/main/java/com/epfl/drawyourpath/database/MockDatabase.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/MockDatabase.kt
@@ -1,6 +1,8 @@
 package com.epfl.drawyourpath.database
 
 import android.graphics.Bitmap
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -20,6 +22,8 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.ValueEventListener
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -724,8 +728,10 @@ class MockDatabase : Database() {
             throw Error("This tournament doesn't exist $tournamentId")
         }
         val postsLiveData = MutableLiveData<List<TournamentPost>>()
-        tournaments[tournamentId]!!.observeForever {
-            postsLiveData.postValue(it.posts)
+        Handler(Looper.getMainLooper()).post {
+            tournaments[tournamentId]!!.observeForever {
+                postsLiveData.postValue(it.posts)
+            }
         }
         return postsLiveData
     }
@@ -742,8 +748,10 @@ class MockDatabase : Database() {
             throw Error("This tournament doesn't exist $tournamentId")
         }
         val infoLiveData = MutableLiveData<Tournament>()
-        tournaments[tournamentId]!!.observeForever {
-            infoLiveData.postValue(it.copy(participants = emptyList(), posts = emptyList()))
+        Handler(Looper.getMainLooper()).post {
+            tournaments[tournamentId]!!.observeForever {
+                infoLiveData.postValue(it.copy(participants = emptyList(), posts = emptyList()))
+            }
         }
         return infoLiveData
     }

--- a/app/src/main/java/com/epfl/drawyourpath/database/MockDatabase.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/MockDatabase.kt
@@ -6,7 +6,6 @@ import android.os.Looper
 import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.Observer
 import com.epfl.drawyourpath.authentication.MockAuth
 import com.epfl.drawyourpath.challenge.dailygoal.DailyGoal
 import com.epfl.drawyourpath.challenge.milestone.MilestoneEnum
@@ -19,11 +18,6 @@ import com.epfl.drawyourpath.path.Path
 import com.epfl.drawyourpath.path.Run
 import com.epfl.drawyourpath.utils.Utils
 import com.google.android.gms.maps.model.LatLng
-import com.google.firebase.database.DataSnapshot
-import com.google.firebase.database.DatabaseError
-import com.google.firebase.database.ValueEventListener
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -628,7 +622,7 @@ class MockDatabase : Database() {
     }
 
     override fun addTournament(tournament: Tournament): CompletableFuture<Unit> {
-        //add the tournament to the list of tournament ids
+        // add the tournament to the list of tournament ids
         MOCK_TOURNAMENTS_ID.postValue((MOCK_TOURNAMENTS_ID.value ?: emptyList()) + tournament.id)
         // Replaces if id already exists, which would happen with Firebase but should never happen as we generate unique ids.
         tournaments[tournament.id] = MutableLiveData(tournament)
@@ -652,7 +646,7 @@ class MockDatabase : Database() {
         // 2. remove the tournament from the tournaments file
         tournaments.remove(tournamentId)
 
-        //3. remove tournament from the tournament id list
+        // 3. remove tournament from the tournament id list
         MOCK_TOURNAMENTS_ID.postValue((MOCK_TOURNAMENTS_ID.value ?: emptyList()).stream().toList().filter { it != tournamentId })
 
         return CompletableFuture.completedFuture(Unit)

--- a/app/src/main/java/com/epfl/drawyourpath/database/MockDatabase.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/MockDatabase.kt
@@ -627,7 +627,7 @@ class MockDatabase : Database() {
         //add the tournament to the list of tournament ids
         MOCK_TOURNAMENTS_ID.postValue((MOCK_TOURNAMENTS_ID.value ?: emptyList()) + tournament.id)
         // Replaces if id already exists, which would happen with Firebase but should never happen as we generate unique ids.
-        tournaments[tournament.id]!!.postValue(tournament)
+        tournaments[tournament.id] = MutableLiveData(tournament)
         return CompletableFuture.completedFuture(Unit)
     }
 

--- a/app/src/main/java/com/epfl/drawyourpath/database/MockNonWorkingDatabase.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/MockNonWorkingDatabase.kt
@@ -8,6 +8,7 @@ import com.epfl.drawyourpath.challenge.milestone.MilestoneEnum
 import com.epfl.drawyourpath.challenge.trophy.Trophy
 import com.epfl.drawyourpath.chat.Message
 import com.epfl.drawyourpath.community.Tournament
+import com.epfl.drawyourpath.community.TournamentPost
 import com.epfl.drawyourpath.path.Run
 import java.time.LocalDate
 import java.util.concurrent.CompletableFuture
@@ -21,6 +22,13 @@ class MockNonWorkingDatabase : Database() {
     }
 
     override fun isTournamentInDatabase(tournamentId: String): CompletableFuture<Boolean> {
+        return failedFuture()
+    }
+
+    override fun isPostInDatabase(
+        tournamentId: String,
+        postId: String,
+    ): CompletableFuture<Boolean> {
         return failedFuture()
     }
 
@@ -119,6 +127,38 @@ class MockNonWorkingDatabase : Database() {
     }
 
     override fun getTournament(tournamentId: String): CompletableFuture<Tournament> {
+        return failedFuture()
+    }
+
+    override fun getTournamentPosts(tournamentId: String): CompletableFuture<List<TournamentPost>> {
+        return failedFuture()
+    }
+
+    override fun getTournamentParticipantsId(tournamentId: String): CompletableFuture<List<String>> {
+        return failedFuture()
+    }
+
+    override fun getTournamentInfo(tournamentId: String): CompletableFuture<Tournament> {
+        return failedFuture()
+    }
+
+    override fun getPostUID(): String? {
+        return null
+    }
+
+    override fun addPostToTournament(
+        tournamentId: String,
+        post: TournamentPost,
+    ): CompletableFuture<Unit> {
+        return failedFuture()
+    }
+
+    override fun voteOnPost(
+        userId: String,
+        tournamentId: String,
+        postId: String,
+        vote: Int,
+    ): CompletableFuture<Unit> {
         return failedFuture()
     }
 

--- a/app/src/main/java/com/epfl/drawyourpath/database/MockNonWorkingDatabase.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/MockNonWorkingDatabase.kt
@@ -100,6 +100,10 @@ class MockNonWorkingDatabase : Database() {
         return failedFuture()
     }
 
+    override fun getAllTournamentsId(): LiveData<List<String>> {
+        throw Exception("")
+    }
+
     override fun getTournamentUID(): String? {
         return null
     }
@@ -126,20 +130,20 @@ class MockNonWorkingDatabase : Database() {
         return failedFuture()
     }
 
-    override fun getTournament(tournamentId: String): CompletableFuture<Tournament> {
-        return failedFuture()
+    override fun getTournament(tournamentId: String): LiveData<Tournament> {
+        throw Exception("")
     }
 
-    override fun getTournamentPosts(tournamentId: String): CompletableFuture<List<TournamentPost>> {
-        return failedFuture()
+    override fun getTournamentPosts(tournamentId: String): LiveData<List<TournamentPost>> {
+        throw Exception("")
     }
 
     override fun getTournamentParticipantsId(tournamentId: String): CompletableFuture<List<String>> {
         return failedFuture()
     }
 
-    override fun getTournamentInfo(tournamentId: String): CompletableFuture<Tournament> {
-        return failedFuture()
+    override fun getTournamentInfo(tournamentId: String): LiveData<Tournament> {
+        throw Exception("")
     }
 
     override fun getPostUID(): String? {
@@ -172,13 +176,11 @@ class MockNonWorkingDatabase : Database() {
     }
 
     override fun getChatPreview(conversationId: String): LiveData<ChatPreview> {
-        // no error in this function
-        return MutableLiveData()
+        throw Exception("")
     }
 
     override fun getChatList(userId: String): LiveData<List<String>> {
-        // no error in this function
-        return MutableLiveData()
+        throw Exception("")
     }
 
     override fun setChatTitle(conversationId: String, newTitle: String): CompletableFuture<Unit> {
@@ -198,8 +200,7 @@ class MockNonWorkingDatabase : Database() {
     }
 
     override fun getChatMessages(conversationId: String): LiveData<List<Message>> {
-        // no error in this function
-        return MutableLiveData()
+        throw Exception("")
     }
 
     override fun addChatMessage(conversationId: String, message: Message): CompletableFuture<Unit> {

--- a/app/src/main/java/com/epfl/drawyourpath/database/MockNonWorkingDatabase.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/MockNonWorkingDatabase.kt
@@ -2,7 +2,6 @@ package com.epfl.drawyourpath.database
 
 import android.graphics.Bitmap
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import com.epfl.drawyourpath.challenge.dailygoal.DailyGoal
 import com.epfl.drawyourpath.challenge.milestone.MilestoneEnum
 import com.epfl.drawyourpath.challenge.trophy.Trophy

--- a/app/src/main/java/com/epfl/drawyourpath/database/MockNonWorkingDatabase.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/MockNonWorkingDatabase.kt
@@ -103,7 +103,7 @@ class MockNonWorkingDatabase : Database() {
         throw Exception("")
     }
 
-    override fun getTournamentUID(): String? {
+    override fun getTournamentUniqueId(): String? {
         return null
     }
 
@@ -145,7 +145,7 @@ class MockNonWorkingDatabase : Database() {
         throw Exception("")
     }
 
-    override fun getPostUID(): String? {
+    override fun getPostUniqueId(): String? {
         return null
     }
 

--- a/app/src/main/java/com/epfl/drawyourpath/database/MockNonWorkingDatabase.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/database/MockNonWorkingDatabase.kt
@@ -184,8 +184,7 @@ class MockNonWorkingDatabase : Database() {
     }
 
     override fun getFriendsList(userId: String): LiveData<List<String>> {
-        // no error in this function
-        return MutableLiveData()
+        throw Exception("")
     }
 
     override fun setChatTitle(conversationId: String, newTitle: String): CompletableFuture<Unit> {

--- a/app/src/main/java/com/epfl/drawyourpath/mainpage/fragments/CommunityFragment.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/mainpage/fragments/CommunityFragment.kt
@@ -277,7 +277,7 @@ class CommunityFragment : Fragment(R.layout.fragment_community) {
             TournamentPost("0", "xxDarkxx", sampleRun()),
             TournamentPost("1", "Michel", sampleRun()),
             TournamentPost("2", "MrPrefect", sampleRun()),
-            TournamentPost("3","Me Myself and I", sampleRun()),
+            TournamentPost("3", "Me Myself and I", sampleRun()),
             TournamentPost("4", "Invalid Username", sampleRun()),
         )
 
@@ -301,14 +301,14 @@ class CommunityFragment : Fragment(R.layout.fragment_community) {
             TournamentPost("0", "xxDarkxx", sampleRun()),
             TournamentPost("1", "Michel", sampleRun()),
             TournamentPost("2", "MrPrefect", sampleRun()),
-            TournamentPost("3","Me Myself and I", sampleRun()),
+            TournamentPost("3", "Me Myself and I", sampleRun()),
             TournamentPost("4", "Invalid Username", sampleRun()),
         )
         val posts1 = mutableListOf(
             TournamentPost("0", "xD c moi", sampleRun()),
             TournamentPost("1", "Jaqueline", sampleRun()),
             TournamentPost("2", "Diabolos", sampleRun()),
-            TournamentPost("3","me", sampleRun()),
+            TournamentPost("3", "me", sampleRun()),
             TournamentPost("4", "IDK", sampleRun()),
         )
         return mutableListOf(
@@ -343,14 +343,14 @@ class CommunityFragment : Fragment(R.layout.fragment_community) {
             TournamentPost("0", "xxDarkxx", sampleRun()),
             TournamentPost("1", "Michel", sampleRun()),
             TournamentPost("2", "MrPrefect", sampleRun()),
-            TournamentPost("3","Me Myself and I", sampleRun()),
+            TournamentPost("3", "Me Myself and I", sampleRun()),
             TournamentPost("4", "Invalid Username", sampleRun()),
         )
         val posts1 = mutableListOf(
             TournamentPost("0", "xD c moi", sampleRun()),
             TournamentPost("1", "Jaqueline", sampleRun()),
             TournamentPost("2", "Diabolos", sampleRun()),
-            TournamentPost("3","me", sampleRun()),
+            TournamentPost("3", "me", sampleRun()),
             TournamentPost("4", "IDK", sampleRun()),
         )
         return mutableListOf(

--- a/app/src/main/java/com/epfl/drawyourpath/mainpage/fragments/CommunityFragment.kt
+++ b/app/src/main/java/com/epfl/drawyourpath/mainpage/fragments/CommunityFragment.kt
@@ -274,11 +274,11 @@ class CommunityFragment : Fragment(R.layout.fragment_community) {
      */
     private fun sampleWeekly(): Tournament {
         val posts = mutableListOf(
-            TournamentPost("xxDarkxx", sampleRun(), -13),
-            TournamentPost("Michel", sampleRun(), 158),
-            TournamentPost("MrPrefect", sampleRun(), 666),
-            TournamentPost("Me Myself and I", sampleRun(), 123456),
-            TournamentPost("Invalid Username", sampleRun(), 0),
+            TournamentPost("0", "xxDarkxx", sampleRun()),
+            TournamentPost("1", "Michel", sampleRun()),
+            TournamentPost("2", "MrPrefect", sampleRun()),
+            TournamentPost("3","Me Myself and I", sampleRun()),
+            TournamentPost("4", "Invalid Username", sampleRun()),
         )
 
         return Tournament(
@@ -298,18 +298,18 @@ class CommunityFragment : Fragment(R.layout.fragment_community) {
      */
     private fun sampleYourTournaments(): List<Tournament> {
         val posts = mutableListOf(
-            TournamentPost("xxDarkxx", sampleRun(), -13),
-            TournamentPost("Michel", sampleRun(), 158),
-            TournamentPost("MrPrefect", sampleRun(), 666),
-            TournamentPost("Me Myself and I", sampleRun(), 123456),
-            TournamentPost("Invalid Username", sampleRun(), 0),
+            TournamentPost("0", "xxDarkxx", sampleRun()),
+            TournamentPost("1", "Michel", sampleRun()),
+            TournamentPost("2", "MrPrefect", sampleRun()),
+            TournamentPost("3","Me Myself and I", sampleRun()),
+            TournamentPost("4", "Invalid Username", sampleRun()),
         )
         val posts1 = mutableListOf(
-            TournamentPost("xD c moi", sampleRun(), 35),
-            TournamentPost("Jaqueline", sampleRun(), 356),
-            TournamentPost("Diabolos", sampleRun(), 666),
-            TournamentPost("me", sampleRun(), -563),
-            TournamentPost("IDK", sampleRun(), 0),
+            TournamentPost("0", "xD c moi", sampleRun()),
+            TournamentPost("1", "Jaqueline", sampleRun()),
+            TournamentPost("2", "Diabolos", sampleRun()),
+            TournamentPost("3","me", sampleRun()),
+            TournamentPost("4", "IDK", sampleRun()),
         )
         return mutableListOf(
             Tournament(
@@ -340,18 +340,18 @@ class CommunityFragment : Fragment(R.layout.fragment_community) {
      */
     private fun sampleDiscoveryTournaments(): List<Tournament> {
         val posts = mutableListOf(
-            TournamentPost("xxDarkxx", sampleRun(), -13),
-            TournamentPost("Michel", sampleRun(), 158),
-            TournamentPost("MrPrefect", sampleRun(), 666),
-            TournamentPost("Me Myself and I", sampleRun(), 123456),
-            TournamentPost("Invalid Username", sampleRun(), 0),
+            TournamentPost("0", "xxDarkxx", sampleRun()),
+            TournamentPost("1", "Michel", sampleRun()),
+            TournamentPost("2", "MrPrefect", sampleRun()),
+            TournamentPost("3","Me Myself and I", sampleRun()),
+            TournamentPost("4", "Invalid Username", sampleRun()),
         )
         val posts1 = mutableListOf(
-            TournamentPost("SpaceMan", sampleRun(), 35),
-            TournamentPost("NASA", sampleRun(), 124),
-            TournamentPost("Diabolos", sampleRun(), 666),
-            TournamentPost("Alien", sampleRun(), -3),
-            TournamentPost("IDK", sampleRun(), 0),
+            TournamentPost("0", "xD c moi", sampleRun()),
+            TournamentPost("1", "Jaqueline", sampleRun()),
+            TournamentPost("2", "Diabolos", sampleRun()),
+            TournamentPost("3","me", sampleRun()),
+            TournamentPost("4", "IDK", sampleRun()),
         )
         return mutableListOf(
             Tournament(


### PR DESCRIPTION
This PR mainly adds the following functions to the database:
- getTournamentInfo()
- getTournamentPosts()
- getTournamentParticipantsId()
- addPostToTournament()
- voteOnPost()

Note that the Firebase functions are not tested, but the utilitary functions used to reconstruct the objects from the database Datasnapshots are tested.

Thanks in advance for your review!

closes #206, closes #208, closes #209, closes #210  